### PR TITLE
fix: expand env variable references in DB URL and batch voter record updates

### DIFF
--- a/apps/report-server/package.json
+++ b/apps/report-server/package.json
@@ -28,6 +28,7 @@
     "async": "^3.2.6",
     "csv-parse": "^6.1.0",
     "dotenv": "^17.2.1",
+    "dotenv-expand": "^12.0.3",
     "express": "^4.21.0",
     "puppeteer": "^23.4.0",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       dotenv:
         specifier: ^17.2.1
         version: 17.2.2
+      dotenv-expand:
+        specifier: ^12.0.3
+        version: 12.0.3
       express:
         specifier: ^4.21.0
         version: 4.21.2
@@ -6881,6 +6884,13 @@ packages:
   /dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
     dev: true
+
+  /dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+    dependencies:
+      dotenv: 16.6.1
+    dev: false
 
   /dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}


### PR DESCRIPTION

- Add dotenv-expand so POSTGRES_PRISMA_URL variable references (e.g. ${POSTGRES_HOST}) are expanded at startup
- Replace individual updateMany() calls with a single batched raw SQL UPDATE for voter record imports