### PR TITLE
3.1a: CommitteeSelector vacancy/weight summary block and empty states

### DIFF
--- a/apps/frontend/src/app/committees/CommitteeSummaryBlock.tsx
+++ b/apps/frontend/src/app/committees/CommitteeSummaryBlock.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent } from "~/components/ui/card";
+
+// NOTE: This block must be preserved in future table-based CommitteeSelector redesign (see SRS_UI_PLANNING_GAPS §15)
+
+export interface CommitteeSummaryBlockProps {
+  vacancyCount: number;
+  totalSeats: number;
+  designationWeight: number | null;
+  missingWeightSeatNumbers?: number[];
+}
+
+function getVacancyBadge(
+  vacancyCount: number,
+  totalSeats: number,
+): { text: string; className: string } {
+  if (vacancyCount === 0) {
+    return { text: "Full", className: "bg-green-100 text-green-800" };
+  }
+  if (vacancyCount === totalSeats) {
+    return {
+      text: `All ${totalSeats} seats vacant`,
+      className: "bg-red-100 text-red-800",
+    };
+  }
+  if (vacancyCount === 1) {
+    return { text: "1 open seat", className: "bg-amber-100 text-amber-800" };
+  }
+  return {
+    text: `${vacancyCount} open seats`,
+    className: "bg-amber-100 text-amber-800",
+  };
+}
+
+/**
+ * Compact summary block showing vacancy status, designation weight, and seat count.
+ * Placed between district selectors and member list in CommitteeSelector.
+ */
+export function CommitteeSummaryBlock({
+  vacancyCount,
+  totalSeats,
+  designationWeight,
+  missingWeightSeatNumbers = [],
+}: CommitteeSummaryBlockProps) {
+  const vacancyBadge = getVacancyBadge(vacancyCount, totalSeats);
+  const occupiedCount = totalSeats - vacancyCount;
+
+  const showWeightDash =
+    designationWeight === null ||
+    missingWeightSeatNumbers.length > 0;
+  const weightDisplay = showWeightDash
+    ? "—"
+    : designationWeight.toFixed(2);
+  const weightTitle =
+    missingWeightSeatNumbers.length > 0
+      ? `Weight unavailable for seats ${missingWeightSeatNumbers.join(", ")}`
+      : undefined;
+
+  return (
+    <Card className="p-4">
+      <CardContent className="flex flex-wrap gap-6 p-0">
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-muted-foreground">Vacancy</span>
+          <span
+            className={`inline-flex w-fit rounded px-2 py-0.5 text-sm font-medium ${vacancyBadge.className}`}
+          >
+            {vacancyBadge.text}
+          </span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-muted-foreground">
+            Designation Weight
+          </span>
+          <span
+            className="font-semibold text-lg"
+            {...(weightTitle ? { title: weightTitle } : {})}
+          >
+            {weightDisplay}
+          </span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-muted-foreground">Seats</span>
+          <span className="font-semibold text-lg">
+            {occupiedCount} of {totalSeats} seats filled
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/docs/SRS/SRS_IMPLEMENTATION_ROADMAP.md
+++ b/docs/SRS/SRS_IMPLEMENTATION_ROADMAP.md
@@ -601,7 +601,7 @@ Adding new privilege levels requires: new enum value, update to permission-order
 | **Depends on** | 1.2 (Membership Status) for vacancy; 2.7 (Weight Logic) for weight |
 | **Priority**   | Medium — satisfies in-app view of open seats and weight            |
 
-**What exists today:** CommitteeSelector shows member cards only. Vacancy is implicit (fewer than 4 members). No weight data.
+**What exists today:** CommitteeSummaryBlock component between district selectors and member list; standardized vacancy badges (Full, 1/N open seats, All N vacant); designation weight with 2-decimal format and "—" fallback; finalized empty states (no jurisdictions, no committees in jurisdictions, no members).
 
 **What to build:**
 

--- a/docs/SRS/SRS_UI_PLANNING_GAPS.md
+++ b/docs/SRS/SRS_UI_PLANNING_GAPS.md
@@ -209,32 +209,19 @@ These are areas that would benefit from more detailed design, wireframes, or spe
 
 ---
 
-## 11. CommitteeSelector Vacancy & Weight Display (Roadmap 3.1a)
+## 11. CommitteeSelector Vacancy & Weight Display (Roadmap 3.1a) — Resolved
 
 **What's planned:** "Display summary: vacancy count (e.g., '2 open seats' or 'Full') and designation weight total."
 
-**UI gaps:**
-
-- **Placement:** "Small summary block in existing flow" — above member cards? Below city/LD/ED selectors? In the committee card header?
-- **Copy:** "2 open seats" vs "Full" — exact wording. "Designation weight: X.XX" — units? Label?
-- **When no weight:** Before 2.7 (Weight Logic) exists — show "—" or hide? Conditional display.
-- **Visual design:** Compact block — font size, color, icon? Consistency with rest of CommitteeSelector.
-
-**Recommendation:** Add a 1–2 line spec: placement (e.g., above member list), copy variants, and fallback when weight unavailable.
+**Resolved by [3.1a](tickets/3.1a-committee-selector-vacancy-weight-empty-states.md):** CommitteeSummaryBlock component defines placement (between district selectors and member list), copy variants (Full, 1 open seat, N open seats, All N seats vacant with color-coded badges), and weight display (rounded to 2 decimals, "—" when unavailable, tooltip for missingWeightSeatNumbers).
 
 ---
 
-## 12. Leader Empty State (Roadmap 3.1)
+## 12. Leader Empty State (Roadmap 3.1) — Resolved
 
 **What's planned:** "Leader with no jurisdictions: Show empty committee list and 'Contact admin to get assigned'."
 
-**UI gaps:**
-
-- **Exact placement:** CommitteeSelector when `committeeLists` is empty — but is empty because of no jurisdictions vs. no committees in the DB? Different messages?
-- **Copy:** "Contact admin to get assigned" — full sentence? Link to help or admin contact?
-- **Consistency:** Same pattern for "no committees in your jurisdiction" (assigned but empty) vs "no jurisdiction assigned"?
-
-**Recommendation:** Define two empty states: (1) No jurisdictions assigned → "Contact an administrator to be assigned committee access." (2) Assigned but no committees → "No committees in your jurisdiction."
+**Resolved by [3.1a](tickets/3.1a-committee-selector-vacancy-weight-empty-states.md):** Two empty states implemented: (1) No jurisdictions assigned → "No Committee Access" / "You have not been assigned any jurisdictions. Contact your county administrator to get committee access." (replaces entire selector). (2) Jurisdictions assigned but no committees → "No Committees Found" with assigned areas list (dropdowns visible but disabled, empty card in member list area).
 
 ---
 

--- a/docs/SRS/tickets/3.1a-committee-selector-vacancy-weight-empty-states.md
+++ b/docs/SRS/tickets/3.1a-committee-selector-vacancy-weight-empty-states.md
@@ -1,6 +1,6 @@
 # 3.1a CommitteeSelector Vacancy/Weight + Empty States
 
-**Status:** Open
+**Status:** Done
 **Roadmap:** [SRS_IMPLEMENTATION_ROADMAP.md](../SRS_IMPLEMENTATION_ROADMAP.md) §3.1a
 **Effort:** 0.5–1 day
 **Depends on:** [2.7 Weight / Designation Logic](2.7-weight-designation-logic.md), [3.1 Jurisdiction Assignment UI](3.1-jurisdiction-assignment-ui.md)
@@ -19,51 +19,51 @@ Deliver the minimal CommitteeSelector UX contract: vacancy/weight summary block 
 ## Acceptance Criteria
 
 ### Summary Block — Placement & Design
-- [ ] Create a `CommitteeSummaryBlock` component placed **between the district selector dropdowns and the member list** in `CommitteeSelector.tsx`.
+- [x] Create a `CommitteeSummaryBlock` component placed **between the district selector dropdowns and the member list** in `CommitteeSelector.tsx`.
   - This is the single canonical location — visible immediately after selecting a committee.
   - Renders as a compact `Card` (not a full table) with 2–3 key metrics.
-- [ ] Summary block shows:
+- [x] Summary block shows:
   - **Vacancy status**: badge or text line
   - **Designation weight total**: labeled number
   - **Seat count**: "X of Y seats filled"
 
 ### Vacancy Copy Variants
-- [ ] Standardize vacancy display copy:
+- [x] Standardize vacancy display copy:
   - `0 open seats` → Show green badge: **"Full"**
   - `1 open seat` → Show amber badge: **"1 open seat"** (singular)
   - `N open seats` (N > 1) → Show amber badge: **"N open seats"** (plural)
   - `maxSeatsPerLted open seats` (all vacant) → Show red badge: **"All N seats vacant"**
-- [ ] Use consistent badge colors from the app's existing design system (Tailwind classes):
+- [x] Use consistent badge colors from the app's existing design system (Tailwind classes):
   - Full: `bg-green-100 text-green-800`
   - Partially vacant: `bg-amber-100 text-amber-800`
   - All vacant: `bg-red-100 text-red-800`
 
 ### Designation Weight Display
-- [ ] Label: **"Designation Weight"** (consistent across UI and reports).
-- [ ] Format: Display as number rounded to 2 decimal places (e.g., `"4.25"`).
-- [ ] Missing weight: Display **"—"** (em dash, not `0` or `N/A`) when:
+- [x] Label: **"Designation Weight"** (consistent across UI and reports).
+- [x] Format: Display as number rounded to 2 decimal places (e.g., `"4.25"`).
+- [x] Missing weight: Display **"—"** (em dash, not `0` or `N/A`) when:
   - No LTED weight is set (`ltedWeight` is null)
   - No petitioned seats exist
   - `missingWeightSeatNumbers` is non-empty (show `—` with tooltip: "Weight unavailable for seats X, Y")
-- [ ] Zero weight (valid): Display **"0.00"** when weight is legitimately calculated as zero.
+- [x] Zero weight (valid): Display **"0.00"** when weight is legitimately calculated as zero.
 
 ### Empty State Copy — Finalized
-- [ ] **No jurisdictions assigned** (Leader with zero `UserJurisdiction` records):
+- [x] **No jurisdictions assigned** (Leader with zero `UserJurisdiction` records):
   - Heading: "No Committee Access"
   - Body: "You have not been assigned any jurisdictions. Contact your county administrator to get committee access."
   - Placement: Replaces the entire committee selector (dropdowns + member list).
   - Style: Centered card with muted text, matching existing `text-muted-foreground` pattern.
-- [ ] **Jurisdictions assigned but no committees** (Leader's jurisdictions match zero committees):
+- [x] **Jurisdictions assigned but no committees** (Leader's jurisdictions match zero committees):
   - Heading: "No Committees Found"
   - Body: "No committees exist in your assigned jurisdictions for the current term. Your assigned areas: [list of cityTown/legDistrict pairs]."
   - Placement: Replaces the member list area (dropdowns still visible but disabled).
-- [ ] **Committee selected but no members** (Admin or Leader with valid selection, zero active memberships):
+- [x] **Committee selected but no members** (Admin or Leader with valid selection, zero active memberships):
   - Body: "No active committee members. Use the form below to add members."
   - Placement: In the member list area. (This is the existing behavior; just standardize the copy.)
 
 ### Future-Proofing Note
-- [ ] Add a code comment on the `CommitteeSummaryBlock` component: `// NOTE: This block must be preserved in future table-based CommitteeSelector redesign (see SRS_UI_PLANNING_GAPS §15)`.
-- [ ] The summary block should be a standalone component that accepts props (`vacancyCount`, `totalSeats`, `designationWeight`, `missingWeightSeats`) rather than being inline in CommitteeSelector — this enables reuse in the future redesign.
+- [x] Add a code comment on the `CommitteeSummaryBlock` component: `// NOTE: This block must be preserved in future table-based CommitteeSelector redesign (see SRS_UI_PLANNING_GAPS §15)`.
+- [x] The summary block should be a standalone component that accepts props (`vacancyCount`, `totalSeats`, `designationWeight`, `missingWeightSeats`) rather than being inline in CommitteeSelector — this enables reuse in the future redesign.
 
 ## Implementation Steps
 

--- a/docs/SRS/tickets/README.md
+++ b/docs/SRS/tickets/README.md
@@ -45,7 +45,8 @@ Implementation tickets for the MCDC Committee Membership & Governance system. Ea
 35. ~~[2.7 Weight / Designation Logic](2.7-weight-designation-logic.md)~~ — **Done**
 36. ~~[3.0 Report-server Migration](3.0-report-server-committee-membership-migration.md)~~ — **Done**
 37. ~~[3.0a Report Audit](3.0a-report-audit-committee-membership.md)~~ — **Done**
-38. **Current queue:** 2.8–2.9, 3.1–3.7, T1.4–T1.5, T2.1–T2.4
+38. ~~[3.1a CommitteeSelector Vacancy/Weight + Empty States](3.1a-committee-selector-vacancy-weight-empty-states.md)~~ — **Done**
+39. **Current queue:** 2.8–2.9, 3.1, 3.2–3.7, T1.4–T1.5, T2.1–T2.4
 
 ---
 
@@ -145,7 +146,7 @@ Implementation tickets for the MCDC Committee Membership & Governance system. Ea
 | [3.0](3.0-report-server-committee-membership-migration.md) | Report-server: Migrate ldCommittees to CommitteeMembership | Done | Tier 3 §3.0 | 1.2 |
 | [3.0a](3.0a-report-audit-committee-membership.md) | Audit and Update All Reports for CommitteeMembership | Done | Tier 3 §3.0a | 3.0 |
 | [3.1](3.1-jurisdiction-assignment-ui.md) | Jurisdiction Assignment UI (Leader Access) | Open | Tier 3 §3.1 | 1.1, IA-01 |
-| [3.1a](3.1a-committee-selector-vacancy-weight-empty-states.md) | CommitteeSelector Vacancy/Weight + Empty States | Open | Tier 3 §3.1a | 2.7, 3.1 |
+| [3.1a](3.1a-committee-selector-vacancy-weight-empty-states.md) | CommitteeSelector Vacancy/Weight + Empty States | Done | Tier 3 §3.1a | 2.7, 3.1 |
 | [3.2](3.2-sign-in-sheet-report-ui.md) | Sign-In Sheet Report UI | Open | Tier 3 §3.2 | 3.0, 3.0a, 3.1 |
 | [3.3](3.3-designation-weight-summary-report-ui.md) | Designation Weight Summary Report UI | Open | Tier 3 §3.3 | 2.7, 3.2 |
 | [3.4](3.4-vacancy-changes-petition-reports-ui.md) | Vacancy, Changes, and Petition Outcomes Reports UI | Open | Tier 3 §3.4 | 2.6, 3.2 |


### PR DESCRIPTION
- Add CommitteeSummaryBlock component with vacancy badges (Full, 1/N open seats, All N vacant), designation weight (2 decimals, — when unavailable), seat count
- Integrate CommitteeSummaryBlock between district selectors and member list
- Finalize empty states: No Committee Access, No Committees Found, No active committee members
- No committees state: dropdowns visible but dimmed, card in member area
- Fix noContentMessage for non-Rochester cities (useLegDistrict check)
- Update SRS docs: 3.1a Done, resolve UI_PLANNING_GAPS §11/§12