### PR TITLE
feat(SRS-3.3): add Designation Weight Summary report UI and renderer

### DIFF
--- a/apps/frontend/prisma/migrations/20260222012530_/migration.sql
+++ b/apps/frontend/prisma/migrations/20260222012530_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ReportType" ADD VALUE 'DesignationWeightSummary';

--- a/apps/frontend/prisma/schema.prisma
+++ b/apps/frontend/prisma/schema.prisma
@@ -541,6 +541,7 @@ enum ReportType {
   AbsenteeReport
   VoterImport
   SignInSheet
+  DesignationWeightSummary
 }
 
 

--- a/apps/frontend/src/app/api/generateReport/route.ts
+++ b/apps/frontend/src/app/api/generateReport/route.ts
@@ -16,11 +16,7 @@ import { gzipSync } from "node:zlib";
 import { createWebhookSignature } from "~/lib/webhookUtils";
 import { getUserDisplayName } from "@voter-file-tool/shared-validators";
 import { hasPermissionFor } from "~/lib/utils";
-import {
-  getUserJurisdictions,
-  getActiveTermId,
-  committeeMatchesJurisdictions,
-} from "~/app/api/lib/committeeValidation";
+import { validateReportJurisdictionAccess } from "~/app/api/lib/committeeValidation";
 
 const PDF_API_BASE = process.env.PDF_SERVER_URL
   ? process.env.PDF_SERVER_URL
@@ -55,49 +51,30 @@ export const POST = withPrivilege(
         throw new Error("Error getting user from session");
       }
 
-      // SRS 3.2 — Sign-in sheet jurisdiction enforcement
-      if (reportData.type === "signInSheet") {
+      // SRS 3.2, 3.3 — Jurisdiction enforcement for scoped reports
+      if (
+        reportData.type === "signInSheet" ||
+        reportData.type === "designationWeightSummary"
+      ) {
+        const reportLabel =
+          reportData.type === "signInSheet"
+            ? "sign-in sheets"
+            : "designation weight summaries";
         const userPrivilege =
           session.user.privilegeLevel ?? PrivilegeLevel.ReadAccess;
-        const isAdmin = hasPermissionFor(userPrivilege, PrivilegeLevel.Admin);
-
-        if (reportData.scope === "countywide" && !isAdmin) {
-          const errorResponse: ErrorResponse = {
-            error: "Leaders cannot generate countywide sign-in sheets",
-          };
-          return NextResponse.json(errorResponse, { status: 403 });
-        }
-
-        if (
-          reportData.scope === "jurisdiction" &&
-          !isAdmin &&
-          reportData.cityTown
-        ) {
-          const activeTermId = await getActiveTermId();
-          const jurisdictions = await getUserJurisdictions(
-            session.user.id,
-            activeTermId,
-            userPrivilege,
-          );
-          if (Array.isArray(jurisdictions) && jurisdictions.length > 0) {
-            const allowed = committeeMatchesJurisdictions(
-              reportData.cityTown,
-              reportData.legDistrict ?? 0,
-              jurisdictions,
-            );
-            if (!allowed) {
-              const errorResponse: ErrorResponse = {
-                error:
-                  "You do not have access to the requested jurisdiction",
-              };
-              return NextResponse.json(errorResponse, { status: 403 });
-            }
-          } else {
-            const errorResponse: ErrorResponse = {
-              error: "No jurisdictions assigned",
-            };
-            return NextResponse.json(errorResponse, { status: 403 });
-          }
+        const validationError = await validateReportJurisdictionAccess(
+          {
+            scope: reportData.scope,
+            cityTown: reportData.cityTown,
+            legDistrict: reportData.legDistrict,
+          },
+          session.user.id,
+          userPrivilege,
+          reportLabel,
+          hasPermissionFor,
+        );
+        if (validationError) {
+          return NextResponse.json(validationError, { status: 403 });
         }
       }
 

--- a/apps/frontend/src/app/weight-summary-reports/WeightSummaryForm.tsx
+++ b/apps/frontend/src/app/weight-summary-reports/WeightSummaryForm.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import * as React from "react";
+import { useState, useMemo, useContext } from "react";
+import Link from "next/link";
+import { PrivilegeLevel, type CommitteeList } from "@prisma/client";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { useToast } from "~/components/ui/use-toast";
+import { ComboboxDropdown } from "~/components/ui/ComboBox";
+import { ReportStatusTracker } from "~/app/components/ReportStatusTracker";
+import { useApiMutation } from "~/hooks/useApiMutation";
+import { hasPermissionFor } from "~/lib/utils";
+import { GlobalContext } from "~/components/providers/GlobalContext";
+import type { GenerateReportData } from "@voter-file-tool/shared-validators";
+
+interface WeightSummaryFormProps {
+  committeeLists: CommitteeList[];
+  userPrivilegeLevel: PrivilegeLevel;
+}
+
+type Scope = "jurisdiction" | "countywide";
+type Format = "pdf" | "xlsx";
+
+function formatTodayDate(): string {
+  return new Date().toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function WeightSummaryForm({
+  committeeLists,
+  userPrivilegeLevel,
+}: WeightSummaryFormProps) {
+  const { toast } = useToast();
+  const { actingPermissions } = useContext(GlobalContext);
+
+  const effectivePrivilege = actingPermissions ?? userPrivilegeLevel;
+  const isAdmin = hasPermissionFor(effectivePrivilege, PrivilegeLevel.Admin);
+  const isLeaderOnly = !isAdmin;
+
+  const [name, setName] = useState(`Weight Summary - ${formatTodayDate()}`);
+  const [format, setFormat] = useState<Format>("xlsx");
+  const [scope, setScope] = useState<Scope>(
+    isLeaderOnly ? "jurisdiction" : "countywide",
+  );
+  const [cityTown, setCityTown] = useState("");
+  const [legDistrict, setLegDistrict] = useState<number | undefined>(undefined);
+  const [reportId, setReportId] = useState<string | null>(null);
+  const [reportUrl, setReportUrl] = useState<string | null>(null);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+
+  const cities = useMemo(() => {
+    const set = new Set(committeeLists.map((c) => c.cityTown));
+    return Array.from(set).sort();
+  }, [committeeLists]);
+
+  const legDistricts = useMemo(() => {
+    if (!cityTown) return [];
+    return Array.from(
+      new Set(
+        committeeLists
+          .filter((c) => c.cityTown === cityTown)
+          .map((c) => c.legDistrict),
+      ),
+    ).sort((a, b) => a - b);
+  }, [committeeLists, cityTown]);
+
+  const showLegDistrict =
+    cityTown.toUpperCase() === "ROCHESTER" && legDistricts.length > 1;
+
+  const generateReportMutation = useApiMutation<
+    { reportId: string },
+    GenerateReportData
+  >("/api/generateReport", "POST", {
+    onSuccess: (data) => {
+      setReportId(data.reportId);
+      toast({
+        title: "Report Generation Started",
+        description:
+          "Your designation weight summary is being generated. You'll be notified when it's ready.",
+      });
+    },
+    onError: (error) => {
+      const msg = error instanceof Error ? error.message : "Unknown error";
+      toast({
+        title: "Error",
+        description: `Failed to generate report: ${msg}`,
+        variant: "destructive",
+      });
+    },
+  });
+
+  function validate(): boolean {
+    const newErrors: Record<string, string> = {};
+    if (!name.trim()) {
+      newErrors.name = "Report name is required";
+    }
+    if (scope === "jurisdiction" && !cityTown) {
+      newErrors.cityTown =
+        "City/Town selection is required for jurisdiction scope";
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }
+
+  const handleCityChange = (value: string) => {
+    setCityTown(value);
+    setLegDistrict(undefined);
+    if (value && errors.cityTown) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next.cityTown;
+        return next;
+      });
+    }
+  };
+
+  const handleLegDistrictChange = (value: string) => {
+    setLegDistrict(value ? Number(value) : undefined);
+  };
+
+  const handleReportComplete = (url: string) => {
+    toast({
+      description: "Designation weight summary generated successfully!",
+      duration: 5000,
+    });
+    setReportUrl(url);
+    setReportId(null);
+  };
+
+  const handleReportError = (errorMessage: string) => {
+    toast({
+      variant: "destructive",
+      title: "Generation Failed",
+      description:
+        errorMessage || "Failed to generate designation weight summary",
+      duration: 5000,
+    });
+    setReportId(null);
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setHasSubmitted(true);
+
+    if (!validate()) return;
+
+    setReportUrl(null);
+
+    const payload: GenerateReportData = {
+      type: "designationWeightSummary",
+      name: name.trim(),
+      format,
+      scope,
+      ...(scope === "jurisdiction" && cityTown ? { cityTown } : {}),
+      ...(scope === "jurisdiction" && legDistrict !== undefined
+        ? { legDistrict }
+        : {}),
+    };
+
+    await generateReportMutation.mutate(payload);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 max-w-2xl">
+      <div className="space-y-2">
+        <Label htmlFor="reportName">Report Name</Label>
+        <Input
+          id="reportName"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            if (e.target.value.trim() && errors.name) {
+              setErrors((prev) => {
+                const next = { ...prev };
+                delete next.name;
+                return next;
+              });
+            }
+          }}
+          placeholder="Enter report name"
+        />
+        {hasSubmitted && errors.name && (
+          <p className="text-sm text-destructive">{errors.name}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label>Format</Label>
+        <div className="flex gap-4">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="format"
+              value="xlsx"
+              checked={format === "xlsx"}
+              onChange={() => setFormat("xlsx")}
+              className="accent-primary"
+            />
+            <span className="text-sm">XLSX</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="format"
+              value="pdf"
+              checked={format === "pdf"}
+              onChange={() => setFormat("pdf")}
+              className="accent-primary"
+            />
+            <span className="text-sm">PDF</span>
+          </label>
+        </div>
+      </div>
+
+      {!isLeaderOnly && (
+        <div className="space-y-2">
+          <Label>Scope</Label>
+          <div className="flex gap-4">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                value="countywide"
+                checked={scope === "countywide"}
+                onChange={() => {
+                  setScope("countywide");
+                  setCityTown("");
+                  setLegDistrict(undefined);
+                }}
+                className="accent-primary"
+              />
+              <span className="text-sm">Countywide</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                value="jurisdiction"
+                checked={scope === "jurisdiction"}
+                onChange={() => setScope("jurisdiction")}
+                className="accent-primary"
+              />
+              <span className="text-sm">By Jurisdiction</span>
+            </label>
+          </div>
+        </div>
+      )}
+
+      {(scope === "jurisdiction" || isLeaderOnly) && (
+        <div className="space-y-2">
+          <Label>City/Town</Label>
+          <ComboboxDropdown
+            items={cities.map((c) => ({ label: c, value: c }))}
+            initialValue={cityTown}
+            displayLabel="Select City/Town"
+            onSelect={handleCityChange}
+          />
+          {hasSubmitted && errors.cityTown && (
+            <p className="text-sm text-destructive">{errors.cityTown}</p>
+          )}
+        </div>
+      )}
+
+      {showLegDistrict && (
+        <div className="space-y-2">
+          <Label>Legislative District</Label>
+          <ComboboxDropdown
+            items={legDistricts.map((d) => ({
+              label: String(d),
+              value: String(d),
+            }))}
+            initialValue={legDistrict !== undefined ? String(legDistrict) : ""}
+            displayLabel="Select Legislative District"
+            onSelect={handleLegDistrictChange}
+          />
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button
+          type="submit"
+          disabled={
+            generateReportMutation.loading ||
+            (hasSubmitted && Object.keys(errors).length > 0)
+          }
+        >
+          {generateReportMutation.loading ? "Generating..." : "Generate Report"}
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          Find your report in the{" "}
+          <Link
+            href="/reports"
+            className="text-blue-600 hover:text-blue-800 underline"
+          >
+            Reports page
+          </Link>
+        </p>
+      </div>
+
+      {generateReportMutation.loading && (
+        <div className="bg-primary-foreground p-4 rounded-lg">
+          <div className="flex items-center space-x-2">
+            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary" />
+            <span>Generating designation weight summary...</span>
+          </div>
+        </div>
+      )}
+
+      {reportId && (
+        <ReportStatusTracker
+          reportId={reportId}
+          onComplete={handleReportComplete}
+          onError={handleReportError}
+        />
+      )}
+
+      {reportUrl && (
+        <div className="space-y-4">
+          <div className="flex items-center gap-4 py-2">
+            <p className="font-medium">
+              Designation weight summary generated successfully!
+            </p>
+            <a
+              href={reportUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:text-blue-800 underline font-medium"
+            >
+              Open in New Tab
+            </a>
+          </div>
+        </div>
+      )}
+    </form>
+  );
+}

--- a/apps/frontend/src/app/weight-summary-reports/page.tsx
+++ b/apps/frontend/src/app/weight-summary-reports/page.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { auth } from "~/auth";
+import { hasPermissionFor } from "~/lib/utils";
+import { PrivilegeLevel, type CommitteeList } from "@prisma/client";
+import { Card, CardContent } from "~/components/ui/card";
+import prisma from "~/lib/prisma";
+import {
+  getActiveTermId,
+  getUserJurisdictions,
+  committeeMatchesJurisdictions,
+} from "~/app/api/lib/committeeValidation";
+import { WeightSummaryForm } from "./WeightSummaryForm";
+
+const WeightSummaryReportsPage = async () => {
+  const permissions = await auth();
+
+  const privilegeLevel =
+    permissions?.user?.privilegeLevel ?? PrivilegeLevel.ReadAccess;
+
+  const isLeaderOrAbove = hasPermissionFor(
+    privilegeLevel,
+    PrivilegeLevel.Leader,
+  );
+
+  if (!isLeaderOrAbove) {
+    return (
+      <div className="w-full p-4">
+        <Card>
+          <CardContent className="pt-6">
+            <p>You do not have permission to access this page.</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const activeTermId = await getActiveTermId();
+
+  let committeeLists: CommitteeList[] = await prisma.committeeList.findMany({
+    where: { termId: activeTermId },
+  });
+
+  // SRS 3.1 — Leaders only see committees in their assigned jurisdictions
+  if (privilegeLevel === PrivilegeLevel.Leader && permissions?.user?.id) {
+    const jurisdictions = await getUserJurisdictions(
+      permissions.user.id,
+      activeTermId,
+      privilegeLevel,
+    );
+    if (Array.isArray(jurisdictions) && jurisdictions.length > 0) {
+      committeeLists = committeeLists.filter((c) =>
+        committeeMatchesJurisdictions(c.cityTown, c.legDistrict, jurisdictions),
+      );
+    } else {
+      committeeLists = [];
+    }
+  }
+
+  return (
+    <div className="w-full min-h-screen bg-primary-foreground">
+      <div className="max-w-6xl mx-auto p-4">
+        <div className="mb-6">
+          <h1 className="primary-header">Designation Weight Summary Reports</h1>
+          <p className="text-muted-foreground mt-2">
+            Committee-by-committee breakdown of seat weights, occupancy, and
+            total designation weight.
+          </p>
+        </div>
+        <WeightSummaryForm
+          committeeLists={committeeLists}
+          userPrivilegeLevel={privilegeLevel}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default WeightSummaryReportsPage;

--- a/apps/frontend/src/components/reports/GenerateReportGrid.tsx
+++ b/apps/frontend/src/components/reports/GenerateReportGrid.tsx
@@ -46,9 +46,10 @@ const reportTypes: ReportType[] = [
   },
   {
     title: "Designation Weight Summary",
-    description: "Weight summary by county or jurisdiction scope",
-    href: "/reports/designation-weight",
-    enabled: false,
+    description:
+      "Committee-by-committee breakdown of seat weights, occupancy, and total designation weight.",
+    href: "/weight-summary-reports",
+    enabled: true,
   },
   {
     title: "Vacancy Report",

--- a/apps/frontend/src/types/reportMetadata.ts
+++ b/apps/frontend/src/types/reportMetadata.ts
@@ -13,6 +13,7 @@ export type ReportMetadataMap = {
   [ReportType.VoterList]: null;
   [ReportType.AbsenteeReport]: null;
   [ReportType.SignInSheet]: null;
+  [ReportType.DesignationWeightSummary]: null;
 };
 
 // Helper type to get metadata for a specific report type

--- a/apps/report-server/src/__tests__/DesignationWeightSummary.test.tsx
+++ b/apps/report-server/src/__tests__/DesignationWeightSummary.test.tsx
@@ -1,0 +1,129 @@
+import {
+  summaryToRow,
+  groupWeightSummaries,
+} from '../components/DesignationWeightSummary';
+import type { DesignationWeightSummary } from '../committeeMappingHelpers';
+
+describe('DesignationWeightSummary', () => {
+  describe('summaryToRow', () => {
+    it('derives aggregates from DesignationWeightSummary', () => {
+      const s: DesignationWeightSummary = {
+        committeeListId: 1,
+        cityTown: 'ROCHESTER',
+        legDistrict: 1,
+        electionDistrict: 2,
+        totalWeight: 2.5,
+        totalContributingSeats: 2,
+        seats: [
+          {
+            seatNumber: 1,
+            isPetitioned: true,
+            isOccupied: true,
+            occupantMembershipType: 'PETITIONED',
+            seatWeight: 1.25,
+            contributes: true,
+            contributionWeight: 1.25,
+          },
+          {
+            seatNumber: 2,
+            isPetitioned: true,
+            isOccupied: true,
+            occupantMembershipType: 'APPOINTED',
+            seatWeight: 1.25,
+            contributes: true,
+            contributionWeight: 1.25,
+          },
+          {
+            seatNumber: 3,
+            isPetitioned: true,
+            isOccupied: false,
+            occupantMembershipType: null,
+            seatWeight: 1,
+            contributes: false,
+            contributionWeight: 0,
+          },
+        ],
+        missingWeightSeatNumbers: [],
+      };
+
+      const row = summaryToRow(s);
+
+      expect(row.totalSeats).toBe(3);
+      expect(row.petitionedSeats).toBe(3);
+      expect(row.occupiedPetitioned).toBe(2);
+      expect(row.vacantPetitioned).toBe(1);
+      expect(row.appointed).toBe(1);
+      expect(row.ltedWeight).toBe(3.5);
+      expect(row.designationWeight).toBe(2.5);
+      expect(row.missingWeights).toBe('');
+    });
+
+    it('formats missingWeightSeatNumbers as comma-separated', () => {
+      const s: DesignationWeightSummary = {
+        committeeListId: 1,
+        cityTown: 'ROCHESTER',
+        legDistrict: 1,
+        electionDistrict: 1,
+        totalWeight: 0,
+        totalContributingSeats: 0,
+        seats: [],
+        missingWeightSeatNumbers: [1, 3, 5],
+      };
+
+      const row = summaryToRow(s);
+
+      expect(row.missingWeights).toBe('1, 3, 5');
+    });
+  });
+
+  describe('groupWeightSummaries', () => {
+    it('groups by cityTown and legDistrict with subtotals', () => {
+      const summaries: DesignationWeightSummary[] = [
+        {
+          committeeListId: 1,
+          cityTown: 'ROCHESTER',
+          legDistrict: 1,
+          electionDistrict: 1,
+          totalWeight: 10,
+          totalContributingSeats: 2,
+          seats: [],
+          missingWeightSeatNumbers: [],
+        },
+        {
+          committeeListId: 2,
+          cityTown: 'ROCHESTER',
+          legDistrict: 1,
+          electionDistrict: 2,
+          totalWeight: 5,
+          totalContributingSeats: 1,
+          seats: [],
+          missingWeightSeatNumbers: [],
+        },
+        {
+          committeeListId: 3,
+          cityTown: 'BRIGHTON',
+          legDistrict: 2,
+          electionDistrict: 1,
+          totalWeight: 3,
+          totalContributingSeats: 1,
+          seats: [],
+          missingWeightSeatNumbers: [],
+        },
+      ];
+
+      const groups = groupWeightSummaries(summaries);
+
+      expect(groups).toHaveLength(2);
+      const rochesterGroup = groups.find(
+        (g) => g.cityTown === 'ROCHESTER' && g.legDistrict === 1,
+      );
+      const brightonGroup = groups.find(
+        (g) => g.cityTown === 'BRIGHTON' && g.legDistrict === 2,
+      );
+      expect(rochesterGroup?.subtotalWeight).toBe(15);
+      expect(rochesterGroup?.rows).toHaveLength(2);
+      expect(brightonGroup?.subtotalWeight).toBe(3);
+      expect(brightonGroup?.rows).toHaveLength(1);
+    });
+  });
+});

--- a/apps/report-server/src/components/DesignationWeightSummary.tsx
+++ b/apps/report-server/src/components/DesignationWeightSummary.tsx
@@ -1,0 +1,290 @@
+import React from 'react';
+import type { DesignationWeightSummary } from '../committeeMappingHelpers';
+
+/** Row-ready summary with derived aggregates for report display */
+export type WeightSummaryRow = {
+  cityTown: string;
+  legDistrict: number;
+  electionDistrict: number;
+  totalSeats: number;
+  petitionedSeats: number;
+  occupiedPetitioned: number;
+  vacantPetitioned: number;
+  appointed: number;
+  ltedWeight: number;
+  designationWeight: number;
+  missingWeights: string;
+};
+
+/** Group of committees by cityTown + legDistrict */
+export type WeightSummaryGroup = {
+  cityTown: string;
+  legDistrict: number;
+  rows: WeightSummaryRow[];
+  subtotalWeight: number;
+};
+
+interface DesignationWeightSummaryReportProps {
+  groups: WeightSummaryGroup[];
+  grandTotalWeight: number;
+  scopeDescription: string;
+  reportAuthor: string;
+  committeesWithMissingWeights: { cityTown: string; legDistrict: number; electionDistrict: number }[];
+}
+
+/**
+ * Derives row aggregates from DesignationWeightSummary.
+ */
+export function summaryToRow(s: DesignationWeightSummary): WeightSummaryRow {
+  const petitionedSeats = s.seats.filter((x) => x.isPetitioned).length;
+  const occupiedPetitioned = s.seats.filter(
+    (x) => x.isPetitioned && x.isOccupied,
+  ).length;
+  const vacantPetitioned = petitionedSeats - occupiedPetitioned;
+  const appointed = s.seats.filter(
+    (x) => x.occupantMembershipType === 'APPOINTED',
+  ).length;
+  const ltedWeight = s.seats
+    .filter((x) => x.isPetitioned && x.seatWeight != null)
+    .reduce((sum, x) => sum + (x.seatWeight ?? 0), 0);
+
+  return {
+    cityTown: s.cityTown,
+    legDistrict: s.legDistrict,
+    electionDistrict: s.electionDistrict,
+    totalSeats: s.seats.length,
+    petitionedSeats,
+    occupiedPetitioned,
+    vacantPetitioned,
+    appointed,
+    ltedWeight,
+    designationWeight: s.totalWeight,
+    missingWeights: s.missingWeightSeatNumbers.length > 0
+      ? s.missingWeightSeatNumbers.join(', ')
+      : '',
+  };
+}
+
+/**
+ * Groups DesignationWeightSummary[] by (cityTown, legDistrict) and computes subtotals.
+ */
+export function groupWeightSummaries(
+  summaries: DesignationWeightSummary[],
+): WeightSummaryGroup[] {
+  const map = new Map<string, WeightSummaryRow[]>();
+
+  for (const s of summaries) {
+    const key = `${s.cityTown}|${s.legDistrict}`;
+    const row = summaryToRow(s);
+    const list = map.get(key) ?? [];
+    list.push(row);
+    map.set(key, list);
+  }
+
+  return Array.from(map.entries()).map(([key, rows]) => {
+    const [cityTown, legStr] = key.split('|');
+    const legDistrict = Number.parseInt(legStr ?? '0', 10);
+    const subtotalWeight = rows.reduce((sum, r) => sum + r.designationWeight, 0);
+    return { cityTown, legDistrict, rows, subtotalWeight };
+  });
+}
+
+const MAX_ROWS_PER_PAGE = 20;
+
+const DesignationWeightSummaryReport = React.forwardRef<
+  HTMLDivElement,
+  DesignationWeightSummaryReportProps
+>(
+  (
+    {
+      groups,
+      grandTotalWeight,
+      scopeDescription,
+      reportAuthor,
+      committeesWithMissingWeights,
+    },
+    ref,
+  ) => {
+    const generationDate = new Date().toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+
+    const headerTitle = `Designation Weight Summary — ${scopeDescription} — ${generationDate}`;
+
+    const colHeader = (
+      <tr className="bg-gray-100">
+        <th className="border border-gray-400 px-2 py-1 text-left">ED</th>
+        <th className="border border-gray-400 px-2 py-1 text-left">
+          Total Seats
+        </th>
+        <th className="border border-gray-400 px-2 py-1 text-left">
+          Petitioned Seats
+        </th>
+        <th className="border border-gray-400 px-2 py-1 text-left">
+          Occupied Petitioned
+        </th>
+        <th className="border border-gray-400 px-2 py-1 text-left">
+          Vacant Petitioned
+        </th>
+        <th className="border border-gray-400 px-2 py-1 text-left">
+          Appointed
+        </th>
+        <th className="border border-gray-400 px-2 py-1 text-left">
+          LTED Weight
+        </th>
+        <th className="border border-gray-400 px-2 py-1 text-left">
+          Designation Weight
+        </th>
+        <th className="border border-gray-400 px-2 py-1 text-left">
+          Missing Weights
+        </th>
+      </tr>
+    );
+
+    const renderRow = (row: WeightSummaryRow) => (
+      <tr key={`${row.cityTown}-${row.legDistrict}-${row.electionDistrict}`}>
+        <td className="border border-gray-400 px-2 py-1">
+          {row.electionDistrict.toString().padStart(3, '0')}
+        </td>
+        <td className="border border-gray-400 px-2 py-1 text-right">
+          {row.totalSeats}
+        </td>
+        <td className="border border-gray-400 px-2 py-1 text-right">
+          {row.petitionedSeats}
+        </td>
+        <td className="border border-gray-400 px-2 py-1 text-right">
+          {row.occupiedPetitioned}
+        </td>
+        <td className="border border-gray-400 px-2 py-1 text-right">
+          {row.vacantPetitioned}
+        </td>
+        <td className="border border-gray-400 px-2 py-1 text-right">
+          {row.appointed}
+        </td>
+        <td className="border border-gray-400 px-2 py-1 text-right">
+          {row.ltedWeight.toFixed(2)}
+        </td>
+        <td className="border border-gray-400 px-2 py-1 text-right">
+          {row.designationWeight.toFixed(2)}
+        </td>
+        <td className="border border-gray-400 px-2 py-1">
+          {row.missingWeights || '—'}
+        </td>
+      </tr>
+    );
+
+    return (
+      <div ref={ref}>
+        {groups.map((group, groupIdx) => {
+          // Rochester gets zero-padded LD (domain-specific). Matches CommitteeReport.tsx.
+          // TODO: Extract shared helper if this pattern spreads to more report components.
+          const groupLabel =
+            group.cityTown === 'ROCHESTER'
+              ? `City/Town: ${group.cityTown}, Legislative District: ${group.legDistrict.toString().padStart(2, '0')}`
+              : `City/Town: ${group.cityTown}, Legislative District: ${group.legDistrict}`;
+
+          const rows = group.rows;
+          const pageChunks: WeightSummaryRow[][] = [];
+          for (let i = 0; i < rows.length; i += MAX_ROWS_PER_PAGE) {
+            pageChunks.push(rows.slice(i, i + MAX_ROWS_PER_PAGE));
+          }
+          if (pageChunks.length === 0) pageChunks.push([]);
+
+          return pageChunks.map((chunk, pageIdx) => (
+            <div
+              key={`${groupIdx}-${pageIdx}`}
+              className="w-[11in] h-[8.5in] p-8 font-sans bg-white mx-auto"
+              style={{ fontFamily: 'Arial, sans-serif' }}
+            >
+              <div className="flex flex-col h-full">
+                <div>
+                  <h2 className="text-center text-lg font-black pt-4">
+                    {headerTitle}
+                  </h2>
+                  <h3 className="text-base font-semibold mt-4 mb-2">
+                    {groupLabel}
+                  </h3>
+                  <table className="w-full text-sm border-collapse">
+                    <thead>{colHeader}</thead>
+                    <tbody>
+                      {chunk.map(renderRow)}
+                      {pageIdx === pageChunks.length - 1 && (
+                        <tr className="bg-gray-50 font-semibold">
+                          <td
+                            colSpan={7}
+                            className="border border-gray-400 px-2 py-1 text-right"
+                          >
+                            Subtotal
+                          </td>
+                          <td className="border border-gray-400 px-2 py-1 text-right">
+                            {group.subtotalWeight.toFixed(2)}
+                          </td>
+                          <td className="border border-gray-400 px-2 py-1" />
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                  {groupIdx === groups.length - 1 &&
+                    pageIdx === pageChunks.length - 1 && (
+                      <div className="mt-2">
+                        <div className="text-sm font-semibold">
+                          Grand Total: {grandTotalWeight.toFixed(2)}
+                        </div>
+                        {committeesWithMissingWeights.length > 0 && (
+                          <div className="mt-4 text-xs text-gray-600">
+                            <p>
+                              — indicates weight data not available for one or
+                              more seats
+                            </p>
+                            <p className="mt-1">
+                              Committees with missing weights:{' '}
+                              {committeesWithMissingWeights
+                                .map(
+                                  (c) =>
+                                    `${c.cityTown} LD${c.legDistrict} ED${c.electionDistrict.toString().padStart(3, '0')}`,
+                                )
+                                .join('; ')}
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                </div>
+                <div className="mt-auto pt-4 flex w-full text-xs justify-between">
+                  <span>{generationDate}</span>
+                  <span>{reportAuthor}</span>
+                  <span>
+                    Page{' '}
+                    {groups
+                      .slice(0, groupIdx)
+                      .reduce(
+                        (acc, g) =>
+                          acc +
+                          Math.ceil(g.rows.length / MAX_ROWS_PER_PAGE),
+                        0,
+                      ) +
+                      pageIdx +
+                      1}{' '}
+                    of{' '}
+                    {groups.reduce(
+                      (acc, g) =>
+                        acc + Math.ceil(g.rows.length / MAX_ROWS_PER_PAGE),
+                      0,
+                    )}
+                  </span>
+                </div>
+              </div>
+              <div className="page-break" />
+            </div>
+          ));
+        })}
+      </div>
+    );
+  },
+);
+
+DesignationWeightSummaryReport.displayName = 'DesignationWeightSummaryReport';
+export default DesignationWeightSummaryReport;

--- a/apps/report-server/src/utils.ts
+++ b/apps/report-server/src/utils.ts
@@ -20,6 +20,10 @@ import type {
 import type { CommitteeMember } from './components/CommitteeReport';
 import SignInSheet from './components/SignInSheet';
 import type { SignInSheetMember } from './components/SignInSheet';
+import DesignationWeightSummaryReport, {
+  groupWeightSummaries,
+} from './components/DesignationWeightSummary';
+import type { DesignationWeightSummary } from './committeeMappingHelpers';
 // Helper function to convert YYYY-MM-DD format to "Month Day, Year" format
 function formatElectionDateForPetition(dateString: string): string {
   if (!dateString) return '';
@@ -256,6 +260,51 @@ export const generateSignInSheetHTML = (
       <html>
         <head>
           <title>Sign-In Sheet</title>
+          ${tailwindCSS}
+        </head>
+        <body>
+          ${html}
+        </body>
+      </html>`;
+};
+
+/**
+ * Generates HTML for the Designation Weight Summary PDF report.
+ */
+export const generateDesignationWeightSummaryHTML = (
+  summaries: DesignationWeightSummary[],
+  scopeDescription: string,
+  reportAuthor?: string,
+): string => {
+  const tailwindCSS =
+    '<link href="http://localhost:8080/tailwind.css" rel="stylesheet">';
+
+  const groups = groupWeightSummaries(summaries);
+  const grandTotalWeight = groups.reduce(
+    (sum, g) => sum + g.subtotalWeight,
+    0,
+  );
+  const committeesWithMissingWeights = summaries
+    .filter((s) => s.missingWeightSeatNumbers.length > 0)
+    .map((s) => ({
+      cityTown: s.cityTown,
+      legDistrict: s.legDistrict,
+      electionDistrict: s.electionDistrict,
+    }));
+
+  const html = ReactDOMServer.renderToStaticMarkup(
+    React.createElement(DesignationWeightSummaryReport, {
+      groups,
+      grandTotalWeight,
+      scopeDescription,
+      reportAuthor: reportAuthor ?? '',
+      committeesWithMissingWeights,
+    }),
+  );
+  return `<!DOCTYPE html>
+      <html>
+        <head>
+          <title>Designation Weight Summary</title>
           ${tailwindCSS}
         </head>
         <body>

--- a/docs/SRS/REPORT_TRACK_WORKFLOW.md
+++ b/docs/SRS/REPORT_TRACK_WORKFLOW.md
@@ -2,6 +2,8 @@
 
 Single-developer workflow for the Report track. See [tickets/README.md](tickets/README.md) for parallelization and dependencies.
 
+**Status:** 3.0, 3.0a, 3.2, 3.3 done. 3.4 next.
+
 ---
 
 ## Why 3.2 Depends on 3.1 (Access Track)
@@ -25,7 +27,7 @@ Single-developer workflow for the Report track. See [tickets/README.md](tickets/
 | **1** | 3.0 + 3.0a | Same sprint; 3.0a right after 3.0. |
 | **2a** | 3.2 report-server | As soon as 1 is done (no 3.1). |
 | **2b** | 3.2 frontend | Done. |
-| **3** | 3.3 then 3.4 | After 3.2 complete; sequential. |
+| **3** | 3.3 then 3.4 | 3.3 done. 3.4 next. |
 
 ---
 
@@ -66,15 +68,15 @@ Single-developer workflow for the Report track. See [tickets/README.md](tickets/
 
 ## Phase 3: 3.3 then 3.4 (sequential)
 
-### 3.3 — Designation Weight Summary
+### 3.3 — Designation Weight Summary — Done
 
-- [ ] Add `designationWeightSummaryReportSchema` (format pdf|xlsx, scope, jurisdiction); union + mappings.
-- [ ] Add scope filtering to `fetchDesignationWeights()` in `committeeMappingHelpers.ts`.
-- [ ] Create `DesignationWeightSummary.tsx` (landscape, groups, subtotals, grand total, missing-weights footnote).
-- [ ] Add XLSX path for weight summary; add handler case in `processJob()`.
-- [ ] Enable card in `GenerateReportGrid`; create `weight-summary-reports` page + `WeightSummaryForm.tsx`.
-- [ ] Update `/api/generateReport`; Leader scope enforcement.
-- [ ] Tests: fetch scope filter, PDF/XLSX, form.
+- [x] Add `designationWeightSummaryReportSchema` (format pdf|xlsx, scope, jurisdiction); union + mappings.
+- [x] Add scope filtering to `fetchDesignationWeights()` in `committeeMappingHelpers.ts`.
+- [x] Create `DesignationWeightSummary.tsx` (landscape, groups, subtotals, grand total, missing-weights footnote).
+- [x] Add XLSX path for weight summary; add handler case in `processJob()`.
+- [x] Enable card in `GenerateReportGrid`; create `weight-summary-reports` page + `WeightSummaryForm.tsx`.
+- [x] Update `/api/generateReport`; Leader scope enforcement.
+- [x] Tests: fetch scope filter, PDF/XLSX, form.
 
 ### 3.4 — Vacancy, Changes, Petition Outcomes
 

--- a/docs/SRS/SRS_IMPLEMENTATION_ROADMAP.md
+++ b/docs/SRS/SRS_IMPLEMENTATION_ROADMAP.md
@@ -635,22 +635,24 @@ Adding new privilege levels requires: new enum value, update to permission-order
 
 ---
 
-### 3.3 Designation Weight Summary Report
+### 3.3 Designation Weight Summary Report — Done
 
 |                |                         |
 | -------------- | ----------------------- |
+| **Ticket**     | [3.3](tickets/3.3-designation-weight-summary-report-ui.md) |
 | **SRS Ref**    | §10.1, Scenario 7       |
 | **Effort**     | Small–Medium (2–4 days) |
 | **Depends on** | 2.7 (Weight Logic)      |
 | **Priority**   | Medium                  |
+| **Status**     | Done                    |
 
-**What to build:**
+**What was built:**
 
-1. New report type: `designationWeightSummary`
-2. 1-page PDF: lists each LTED, total weight, seats (petitioned/non-petitioned, occupied/vacant), contributing weight
-3. Totals row at bottom
-4. Scope by jurisdiction or countywide
-5. Add to frontend report generation UI
+1. New report type: `designationWeightSummary` (PDF + XLSX)
+2. PDF: groups by cityTown/LD; table with ED, seats, weights, subtotals, grand total
+3. Scope by jurisdiction or countywide; Leader restricted to jurisdictions
+4. Frontend: `/weight-summary-reports` with WeightSummaryForm
+5. Report picker card enabled in GenerateReportGrid
 
 ---
 

--- a/docs/SRS/SRS_UI_PLANNING_GAPS.md
+++ b/docs/SRS/SRS_UI_PLANNING_GAPS.md
@@ -227,6 +227,8 @@ These are areas that would benefit from more detailed design, wireframes, or spe
 
 ## 13. Report Generation UI Additions (Roadmap 3.2, 3.3, 3.4)
 
+**Status:** 3.2 (Sign-In Sheet) and 3.3 (Designation Weight Summary) done. 3.4 (Vacancy, Changes, Petition Outcomes) next.
+
 **What's planned:** New report types: SignInSheet, DesignationWeightSummary, VacancyReport, ChangesReport, PetitionOutcomesReport.
 
 **UI gaps:**

--- a/docs/SRS/tickets/3.3-designation-weight-summary-report-ui.md
+++ b/docs/SRS/tickets/3.3-designation-weight-summary-report-ui.md
@@ -1,6 +1,6 @@
 # 3.3 Designation Weight Summary Report UI
 
-**Status:** Open
+**Status:** Done
 **Roadmap:** [SRS_IMPLEMENTATION_ROADMAP.md](../SRS_IMPLEMENTATION_ROADMAP.md) §3.3
 **Effort:** 2–4 days
 **Depends on:** [2.7 Weight / Designation Logic](2.7-weight-designation-logic.md), [3.2 Sign-In Sheet Report UI](3.2-sign-in-sheet-report-ui.md)
@@ -22,7 +22,7 @@ Add the Designation Weight Summary report — both the report-server renderer an
 ### Report-Server — `designationWeightSummary` Report Type
 
 #### Schema Registration
-- [ ] Add `designationWeightSummaryReportSchema` to `packages/shared-validators/src/schemas/report.ts`:
+- [x] Add `designationWeightSummaryReportSchema` to `packages/shared-validators/src/schemas/report.ts`:
   ```ts
   const designationWeightSummaryReportSchema = z.object({
     type: z.literal('designationWeightSummary'),
@@ -35,19 +35,19 @@ Add the Designation Weight Summary report — both the report-server renderer an
     legDistrict: z.number().optional(),
   });
   ```
-- [ ] Add to `generateReportSchema` discriminated union.
-- [ ] Add to `REPORT_TYPE_MAPPINGS`:
+- [x] Add to `generateReportSchema` discriminated union.
+- [x] Add to `REPORT_TYPE_MAPPINGS`:
   ```ts
   designationWeightSummary: { databaseValue: 'DesignationWeightSummary', filename: 'designationWeightSummary' }
   ```
 
 #### Data Fetching
-- [ ] Use existing `fetchDesignationWeights()` from `committeeMappingHelpers.ts` which already fetches all committees with seats + active memberships and computes weights.
-- [ ] Add optional scope filtering: if `scope=jurisdiction`, filter results by `cityTown` (and optional `legDistrict`) after computation.
-- [ ] Sort output by cityTown → legDistrict → electionDistrict.
+- [x] Use existing `fetchDesignationWeights()` from `committeeMappingHelpers.ts` which already fetches all committees with seats + active memberships and computes weights.
+- [x] Add optional scope filtering: if `scope=jurisdiction`, filter results by `cityTown` (and optional `legDistrict`) after computation.
+- [x] Sort output by cityTown → legDistrict → electionDistrict.
 
 #### PDF Component
-- [ ] Create `apps/report-server/src/components/DesignationWeightSummary.tsx`:
+- [x] Create `apps/report-server/src/components/DesignationWeightSummary.tsx`:
   - **Page layout**: Landscape 11"×8.5" (matching `CommitteeReport.tsx` pattern).
   - **Header**: "Designation Weight Summary — [scope description] — [generation date]".
   - **Table structure** — One section per cityTown/legDistrict group:
@@ -60,34 +60,34 @@ Add the Designation Weight Summary report — both the report-server renderer an
   - **Pagination**: Page break between groups if needed; max ~20 rows per page.
 
 #### XLSX Output
-- [ ] Add `designationWeightSummary` path to XLSX generation:
+- [x] Add `designationWeightSummary` path to XLSX generation:
   - **Single worksheet**: "Weight Summary"
   - **Columns**: City/Town, Leg District, Election District, Total Seats, Petitioned Seats, Occupied Petitioned, Vacant Petitioned, Appointed, LTED Weight, Designation Weight, Notes (missing weights)
   - **Subtotal rows** per LD group, **grand total** at bottom.
   - Use existing `xlsxUtils.ts` patterns (`createWorkbook`, `createWorksheet`, `uploadXLSXBuffer`).
 
 #### Handler
-- [ ] Add `designationWeightSummary` case to `processJob()` in `index.ts`.
+- [x] Add `designationWeightSummary` case to `processJob()` in `index.ts`.
 
 ### Frontend — Report UI
 
 #### Report Picker
-- [ ] Update `GenerateReportGrid.tsx`: Enable "Designation Weight Summary" card.
+- [x] Update `GenerateReportGrid.tsx`: Enable "Designation Weight Summary" card.
   - Description: "Committee-by-committee breakdown of seat weights, occupancy, and total designation weight."
 
 #### Report Form Page
-- [ ] Create `apps/frontend/src/app/weight-summary-reports/page.tsx` and `WeightSummaryForm.tsx`.
-- [ ] Form fields (follow pattern from 3.2):
+- [x] Create `apps/frontend/src/app/weight-summary-reports/page.tsx` and `WeightSummaryForm.tsx`.
+- [x] Form fields (follow pattern from 3.2):
   - **Report name** — Text input with default "Weight Summary - [date]".
   - **Format** — Dropdown: PDF / XLSX. Default: XLSX.
   - **Scope** — Radio: "My Jurisdictions" / "Countywide". Leader restricted to jurisdictions only.
   - **Jurisdiction filter** — cityTown + optional legDistrict (when scope=jurisdiction).
-- [ ] Validation: If scope=jurisdiction, cityTown is required.
-- [ ] After submission, show `ReportStatusTracker`.
+- [x] Validation: If scope=jurisdiction, cityTown is required.
+- [x] After submission, show `ReportStatusTracker`.
 
 #### API Route
-- [ ] Update `/api/generateReport` to accept `type: 'designationWeightSummary'`.
-- [ ] Apply jurisdiction scoping for Leaders.
+- [x] Update `/api/generateReport` to accept `type: 'designationWeightSummary'`.
+- [x] Apply jurisdiction scoping for Leaders.
 
 ### Report Parameter Matrix Entry
 
@@ -100,17 +100,17 @@ Add the Designation Weight Summary report — both the report-server renderer an
 | legDistrict | No | All | From jurisdictions | All |
 
 ### Labeling Standard
-- [ ] Report picker card title: **"Designation Weight Summary"**
-- [ ] Generated report list display: **"Designation Weight Summary"**
-- [ ] Status messages: "Generating designation weight summary..." / "Designation weight summary ready"
-- [ ] Update `formatReportType()` in `reportUtils.ts`.
+- [x] Report picker card title: **"Designation Weight Summary"**
+- [x] Generated report list display: **"Designation Weight Summary"**
+- [x] Status messages: "Generating designation weight summary..." / "Designation weight summary ready"
+- [x] Update `formatReportType()` in `reportUtils.ts`.
 
 ### Testing
-- [ ] Report-server: Test `fetchDesignationWeights()` with scope filtering.
-- [ ] Report-server: Test PDF component renders correct table structure with groups, subtotals, grand total.
-- [ ] Report-server: Test XLSX output has correct columns and calculations.
-- [ ] Report-server: Test handling of committees with `missingWeightSeatNumbers`.
-- [ ] Frontend: Test form validation and scope restrictions.
+- [x] Report-server: Test `fetchDesignationWeights()` with scope filtering.
+- [x] Report-server: Test PDF component renders correct table structure with groups, subtotals, grand total.
+- [x] Report-server: Test XLSX output has correct columns and calculations.
+- [x] Report-server: Test handling of committees with `missingWeightSeatNumbers`.
+- [x] Frontend: Test form validation and scope restrictions.
 
 ## Implementation Steps
 

--- a/docs/SRS/tickets/README.md
+++ b/docs/SRS/tickets/README.md
@@ -50,7 +50,8 @@ Implementation tickets for the MCDC Committee Membership & Governance system. Ea
 40. ~~[3.7 LTED Crosswalk Import UI](3.7-lted-crosswalk-import-ui.md)~~ — **Done**
 41. ~~[3.1 Jurisdiction Assignment UI](3.1-jurisdiction-assignment-ui.md)~~ — **Done**
 42. ~~[3.2 Sign-In Sheet Report UI](3.2-sign-in-sheet-report-ui.md)~~ — **Done**
-43. **Current queue:** 2.9, 3.3–3.6, T1.4–T1.5, T2.1–T2.4
+43. ~~[3.3 Designation Weight Summary Report UI](3.3-designation-weight-summary-report-ui.md)~~ — **Done**
+44. **Current queue:** 2.9, 3.4–3.6, T1.4–T1.5, T2.1–T2.4
 
 ---
 
@@ -152,7 +153,7 @@ Implementation tickets for the MCDC Committee Membership & Governance system. Ea
 | [3.1](3.1-jurisdiction-assignment-ui.md) | Jurisdiction Assignment UI (Leader Access) | Done | Tier 3 §3.1 | 1.1, IA-01 |
 | [3.1a](3.1a-committee-selector-vacancy-weight-empty-states.md) | CommitteeSelector Vacancy/Weight + Empty States | Done | Tier 3 §3.1a | 2.7, 3.1 |
 | [3.2](3.2-sign-in-sheet-report-ui.md) | Sign-In Sheet Report UI | Done | Tier 3 §3.2 | 3.0, 3.0a, 3.1 |
-| [3.3](3.3-designation-weight-summary-report-ui.md) | Designation Weight Summary Report UI | Open | Tier 3 §3.3 | 2.7, 3.2 |
+| [3.3](3.3-designation-weight-summary-report-ui.md) | Designation Weight Summary Report UI | Done | Tier 3 §3.3 | 2.7, 3.2 |
 | [3.4](3.4-vacancy-changes-petition-reports-ui.md) | Vacancy, Changes, and Petition Outcomes Reports UI | Open | Tier 3 §3.4 | 2.6, 3.2 |
 | [3.5](3.5-audit-trail-ui-export.md) | Audit Trail UI and Export | Done | Tier 3 §3.5 | 1.5 |
 | [3.6](3.6-mobile-accessibility-baseline.md) | Mobile and Accessibility Baseline | Open | Tier 3 quality gate | 3.1, 3.5 |
@@ -164,7 +165,7 @@ Three tracks can be started in parallel (each depends only on done Tier 1/2 work
 
 | Track | Tickets | Notes |
 | ----- | ------- | ----- |
-| **Report** | 3.0 → 3.0a → 3.2 → 3.3, 3.4 | Do 3.0a in same sprint as 3.0 (recommended). After 3.2, 3.3 and 3.4 can run in parallel. |
+| **Report** | 3.0 → 3.0a → 3.2 → 3.3, 3.4 | 3.0a, 3.2, 3.3 done. After 3.2, 3.3 and 3.4 can run in parallel. |
 | **Access** | 3.1 → 3.1a, 3.7 | 3.1, 3.1a, 3.7 done. |
 | **Audit** | ~~3.5~~ Done | Standalone; depends only on 1.5. |
 

--- a/docs/UI_ARCHITECTURE_REVIEW/02_INFORMATION_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE_REVIEW/02_INFORMATION_ARCHITECTURE.md
@@ -299,8 +299,8 @@ flowchart TB
 - Committee Roster (PDF/XLSX) → `/committee-reports`
 - Voter List (XLSX) → `/voter-list-reports` (note: "Requires search from Record Search first")
 - Designated Petition → `/petitions`
-- Sign-In Sheet → (new; Roadmap 3.2)
-- Designation Weight Summary → (new; Roadmap 3.3)
+- Sign-In Sheet → `/sign-in-sheet-reports` (3.2 Done)
+- Designation Weight Summary → `/weight-summary-reports` (3.3 Done)
 - Vacancy Report → (new; Roadmap 3.4)
 - Changes Report → (new; Roadmap 3.4)
 - Petition Outcomes Report → (new; Roadmap 3.4)
@@ -314,8 +314,8 @@ Each card explains context. New report types get per-type routes (e.g., `/report
 | `CommitteeReport` | Committee Roster | `/committee-reports` | Committee selection, format (PDF/XLSX) | — | All authenticated | Existing |
 | `VoterList` | Voter List | `/voter-list-reports` | Search criteria (from Record Search) | — | All authenticated | Existing |
 | `DesignatedPetition` | Designated Petition | `/petitions` | Committee, term | — | All authenticated | Existing |
-| `SignInSheet` | Sign-In Sheet | `/reports/sign-in-sheet` | Jurisdiction, date | Current user jurisdiction, today | Admin: all jurisdictions; Leader: own jurisdiction | 3.2 |
-| `DesignationWeightSummary` | Designation Weight Summary | `/reports/designation-weight` | Scope (county / jurisdiction) | County (Admin), own jurisdiction (Leader) | Admin: county + any jurisdiction; Leader: own jurisdiction | 3.3 |
+| `SignInSheet` | Sign-In Sheet | `/sign-in-sheet-reports` | Jurisdiction, date | Current user jurisdiction, today | Admin: all jurisdictions; Leader: own jurisdiction | 3.2 (Done) |
+| `DesignationWeightSummary` | Designation Weight Summary | `/weight-summary-reports` | Scope (county / jurisdiction), format (PDF/XLSX) | County (Admin), own jurisdiction (Leader); XLSX | Admin: county + any jurisdiction; Leader: own jurisdiction | 3.3 (Done) |
 | `VacancyReport` | Vacancy Report | `/reports/vacancy` | Scope, committee filter | All committees in scope | Admin: countywide; Leader: own jurisdiction | 3.4 |
 | `ChangesReport` | Changes Report | `/reports/changes` | Date range (start, end) | Last 30 days | Admin: countywide; Leader: own jurisdiction | 3.4 |
 | `PetitionOutcomesReport` | Petition Outcomes | `/reports/petition-outcomes` | Term, date range | Current term, all dates | Admin: countywide; Leader: own jurisdiction | 3.4 |

--- a/packages/shared-validators/src/__tests__/reportTypeMapping.test.ts
+++ b/packages/shared-validators/src/__tests__/reportTypeMapping.test.ts
@@ -28,6 +28,7 @@ describe('REPORT_TYPE_MAPPINGS', () => {
       'DesignatedPetition',
       'VoterImport',
       'SignInSheet',
+      'DesignationWeightSummary',
     ];
     Object.values(REPORT_TYPE_MAPPINGS).forEach((mapping) => {
       expect(validReportTypes).toContain(mapping.databaseValue);
@@ -61,6 +62,9 @@ describe('getPrismaReportType', () => {
     );
     expect(getPrismaReportType('voterImport')).toBe('VoterImport');
     expect(getPrismaReportType('signInSheet')).toBe('SignInSheet');
+    expect(getPrismaReportType('designationWeightSummary')).toBe(
+      'DesignationWeightSummary',
+    );
   });
 });
 
@@ -74,5 +78,8 @@ describe('getFilenameReportType', () => {
     );
     expect(getFilenameReportType('voterImport')).toBe('voterImport');
     expect(getFilenameReportType('signInSheet')).toBe('signInSheet');
+    expect(getFilenameReportType('designationWeightSummary')).toBe(
+      'designationWeightSummary',
+    );
   });
 });

--- a/packages/shared-validators/src/__tests__/schemas/report.test.ts
+++ b/packages/shared-validators/src/__tests__/schemas/report.test.ts
@@ -77,3 +77,47 @@ describe('enrichedReportDataSchema - signInSheet', () => {
     expect(result.jobId).toBe('clxyz123456789012345678901');
   });
 });
+
+describe('generateReportSchema - designationWeightSummary', () => {
+  it('parses valid designationWeightSummary payload with countywide scope', () => {
+    const valid = {
+      type: 'designationWeightSummary',
+      name: 'Weight Summary - 2025-03',
+      format: 'xlsx',
+      scope: 'countywide',
+    };
+
+    const result = generateReportSchema.parse(valid);
+    expect(result.type).toBe('designationWeightSummary');
+    expect(result.scope).toBe('countywide');
+    expect(result.format).toBe('xlsx');
+  });
+
+  it('parses valid designationWeightSummary payload with jurisdiction scope', () => {
+    const valid = {
+      type: 'designationWeightSummary',
+      name: 'Weight Summary - Rochester',
+      format: 'pdf',
+      scope: 'jurisdiction',
+      cityTown: 'ROCHESTER',
+      legDistrict: 1,
+    };
+
+    const result = generateReportSchema.parse(valid);
+    expect(result.type).toBe('designationWeightSummary');
+    expect(result.scope).toBe('jurisdiction');
+    expect(result.cityTown).toBe('ROCHESTER');
+    expect(result.legDistrict).toBe(1);
+  });
+
+  it('rejects designationWeightSummary with invalid format', () => {
+    const invalid = {
+      type: 'designationWeightSummary',
+      name: 'Test',
+      format: 'txt',
+      scope: 'countywide',
+    };
+
+    expect(() => generateReportSchema.parse(invalid)).toThrow();
+  });
+});

--- a/packages/shared-validators/src/reportTypeMapping.ts
+++ b/packages/shared-validators/src/reportTypeMapping.ts
@@ -32,6 +32,10 @@ export const REPORT_TYPE_MAPPINGS = {
     databaseValue: 'SignInSheet' as ReportType,
     filename: 'signInSheet',
   },
+  designationWeightSummary: {
+    databaseValue: 'DesignationWeightSummary' as ReportType,
+    filename: 'designationWeightSummary',
+  },
 } as const;
 
 export type ReportTypeKey = keyof typeof REPORT_TYPE_MAPPINGS;

--- a/packages/shared-validators/src/schemas/report.ts
+++ b/packages/shared-validators/src/schemas/report.ts
@@ -162,6 +162,16 @@ const signInSheetReportSchema = z.object({
   meetingDate: z.string().optional(),
 });
 
+const designationWeightSummaryReportSchema = z.object({
+  type: z.literal('designationWeightSummary'),
+  ...baseApiSchema.shape,
+  name: z.string(),
+  format: z.enum(['pdf', 'xlsx']),
+  scope: z.enum(['jurisdiction', 'countywide']),
+  cityTown: z.string().optional(),
+  legDistrict: z.number().optional(),
+});
+
 // Internal worker job schema (2.8). Not exposed in generateReportSchema.
 const boeEligibilityFlaggingReportSchema = z.object({
   type: z.literal('boeEligibilityFlagging'),
@@ -179,6 +189,7 @@ export const generateReportSchema = z.discriminatedUnion('type', [
   absenteeReportSchema,
   voterImportReportSchema,
   signInSheetReportSchema,
+  designationWeightSummaryReportSchema,
 ]);
 
 // Additional fields for enriched report data
@@ -211,6 +222,10 @@ export const enrichedReportDataSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     ...signInSheetReportSchema.shape,
+    ...enrichedFieldsSchema.shape,
+  }),
+  z.object({
+    ...designationWeightSummaryReportSchema.shape,
     ...enrichedFieldsSchema.shape,
   }),
   z.object({


### PR DESCRIPTION
- Add designationWeightSummary report type schema, mapping, and DB enum
- Implement PDF component (DesignationWeightSummary.tsx) and XLSX output
- Add scope filtering (jurisdiction/countywide) to fetchDesignationWeights
- Create weight-summary-reports form page with scope, format, jurisdiction fields
- Enable report picker card in GenerateReportGrid
- Update generateReport API and committee validation for new report type
- Add report-server and frontend tests