### PR TITLE
feat(3.4): Vacancy, Changes, and Petition Outcomes Reports UI

### DIFF
--- a/apps/frontend/prisma/migrations/20260222015721_/migration.sql
+++ b/apps/frontend/prisma/migrations/20260222015721_/migration.sql
@@ -1,0 +1,11 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "ReportType" ADD VALUE 'VacancyReport';
+ALTER TYPE "ReportType" ADD VALUE 'ChangesReport';
+ALTER TYPE "ReportType" ADD VALUE 'PetitionOutcomesReport';

--- a/apps/frontend/prisma/schema.prisma
+++ b/apps/frontend/prisma/schema.prisma
@@ -542,6 +542,9 @@ enum ReportType {
   VoterImport
   SignInSheet
   DesignationWeightSummary
+  VacancyReport
+  ChangesReport
+  PetitionOutcomesReport
 }
 
 

--- a/apps/frontend/src/app/api/generateReport/route.ts
+++ b/apps/frontend/src/app/api/generateReport/route.ts
@@ -51,15 +51,26 @@ export const POST = withPrivilege(
         throw new Error("Error getting user from session");
       }
 
-      // SRS 3.2, 3.3 — Jurisdiction enforcement for scoped reports
+      // SRS 3.2, 3.3, 3.4 — Jurisdiction enforcement for scope-based reports
+      const scopeReportTypes = [
+        "signInSheet",
+        "designationWeightSummary",
+        "vacancyReport",
+        "changesReport",
+        "petitionOutcomesReport",
+      ] as const;
       if (
-        reportData.type === "signInSheet" ||
-        reportData.type === "designationWeightSummary"
+        scopeReportTypes.includes(
+          reportData.type as (typeof scopeReportTypes)[number],
+        )
       ) {
-        const reportLabel =
-          reportData.type === "signInSheet"
-            ? "sign-in sheets"
-            : "designation weight summaries";
+        const reportLabel = {
+          signInSheet: "sign-in sheets",
+          designationWeightSummary: "designation weight summaries",
+          vacancyReport: "vacancy reports",
+          changesReport: "changes reports",
+          petitionOutcomesReport: "petition outcomes reports",
+        }[reportData.type];
         const userPrivilege =
           session.user.privilegeLevel ?? PrivilegeLevel.ReadAccess;
         const validationError = await validateReportJurisdictionAccess(

--- a/apps/frontend/src/app/changes-reports/ChangesReportForm.tsx
+++ b/apps/frontend/src/app/changes-reports/ChangesReportForm.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import * as React from "react";
+import { useState, useMemo, useContext } from "react";
+import Link from "next/link";
+import { PrivilegeLevel, type CommitteeList } from "@prisma/client";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { useToast } from "~/components/ui/use-toast";
+import { ComboboxDropdown } from "~/components/ui/ComboBox";
+import { ReportStatusTracker } from "~/app/components/ReportStatusTracker";
+import { useApiMutation } from "~/hooks/useApiMutation";
+import { hasPermissionFor } from "~/lib/utils";
+import { GlobalContext } from "~/components/providers/GlobalContext";
+import type { GenerateReportData } from "@voter-file-tool/shared-validators";
+
+interface ChangesReportFormProps {
+  committeeLists: CommitteeList[];
+  userPrivilegeLevel: PrivilegeLevel;
+}
+
+type Scope = "jurisdiction" | "countywide";
+
+function formatTodayDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function last30Days(): { from: string; to: string } {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(from.getDate() - 30);
+  return {
+    from: from.toISOString().slice(0, 10),
+    to: to.toISOString().slice(0, 10),
+  };
+}
+
+export function ChangesReportForm({
+  committeeLists,
+  userPrivilegeLevel,
+}: ChangesReportFormProps) {
+  const { toast } = useToast();
+  const { actingPermissions } = useContext(GlobalContext);
+
+  const effectivePrivilege = actingPermissions ?? userPrivilegeLevel;
+  const isAdmin = hasPermissionFor(effectivePrivilege, PrivilegeLevel.Admin);
+  const isLeaderOnly = !isAdmin;
+
+  const defaultRange = last30Days();
+  const [name, setName] = useState(`Changes Report - ${formatTodayDate()}`);
+  const [format, setFormat] = useState<"pdf" | "xlsx">("xlsx");
+  const [scope, setScope] = useState<Scope>(
+    isLeaderOnly ? "jurisdiction" : "countywide",
+  );
+  const [cityTown, setCityTown] = useState("");
+  const [legDistrict, setLegDistrict] = useState<number | undefined>(undefined);
+  const [dateFrom, setDateFrom] = useState(defaultRange.from);
+  const [dateTo, setDateTo] = useState(defaultRange.to);
+  const [reportId, setReportId] = useState<string | null>(null);
+  const [reportUrl, setReportUrl] = useState<string | null>(null);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+
+  const cities = useMemo(() => {
+    const set = new Set(committeeLists.map((c) => c.cityTown));
+    return Array.from(set).sort();
+  }, [committeeLists]);
+
+  const legDistricts = useMemo(() => {
+    if (!cityTown) return [];
+    return Array.from(
+      new Set(
+        committeeLists
+          .filter((c) => c.cityTown === cityTown)
+          .map((c) => c.legDistrict),
+      ),
+    ).sort((a, b) => a - b);
+  }, [committeeLists, cityTown]);
+
+  const showLegDistrict =
+    cityTown.toUpperCase() === "ROCHESTER" && legDistricts.length > 1;
+
+  const generateReportMutation = useApiMutation<
+    { reportId: string },
+    GenerateReportData
+  >("/api/generateReport", "POST", {
+    onSuccess: (data) => {
+      setReportId(data.reportId);
+      toast({
+        title: "Report Generation Started",
+        description: "Your changes report is being generated.",
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: "Error",
+        description: `Failed to generate report: ${error instanceof Error ? error.message : "Unknown error"}`,
+        variant: "destructive",
+      });
+    },
+  });
+
+  function validate(): boolean {
+    const newErrors: Record<string, string> = {};
+    if (!name.trim()) newErrors.name = "Report name is required";
+    if (scope === "jurisdiction" && !cityTown) {
+      newErrors.cityTown = "City/Town selection is required for jurisdiction scope";
+    }
+    if (!dateFrom) newErrors.dateFrom = "Start date is required";
+    if (!dateTo) newErrors.dateTo = "End date is required";
+    if (dateFrom && dateTo && dateFrom > dateTo) {
+      newErrors.dateTo = "End date must be on or after start date";
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }
+
+  const handleCityChange = (value: string) => {
+    setCityTown(value);
+    setLegDistrict(undefined);
+    if (value && errors.cityTown) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next.cityTown;
+        return next;
+      });
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setHasSubmitted(true);
+    if (!validate()) return;
+    setReportUrl(null);
+
+    const payload: GenerateReportData = {
+      type: "changesReport",
+      name: name.trim(),
+      format,
+      scope,
+      dateFrom,
+      dateTo,
+      ...(scope === "jurisdiction" && cityTown ? { cityTown } : {}),
+      ...(scope === "jurisdiction" && legDistrict !== undefined
+        ? { legDistrict }
+        : {}),
+    };
+
+    await generateReportMutation.mutate(payload);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 max-w-2xl">
+      <div className="space-y-2">
+        <Label htmlFor="reportName">Report Name</Label>
+        <Input
+          id="reportName"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Enter report name"
+        />
+        {hasSubmitted && errors.name && (
+          <p className="text-sm text-destructive">{errors.name}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label>Format</Label>
+        <select
+          value={format}
+          onChange={(e) => setFormat(e.target.value as "pdf" | "xlsx")}
+          className="border rounded px-3 py-2 w-full max-w-[120px]"
+        >
+          <option value="pdf">PDF</option>
+          <option value="xlsx">XLSX</option>
+        </select>
+      </div>
+
+      {!isLeaderOnly && (
+        <div className="space-y-2">
+          <Label>Scope</Label>
+          <div className="flex gap-4">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                value="countywide"
+                checked={scope === "countywide"}
+                onChange={() => {
+                  setScope("countywide");
+                  setCityTown("");
+                  setLegDistrict(undefined);
+                }}
+                className="accent-primary"
+              />
+              <span className="text-sm">Countywide</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                value="jurisdiction"
+                checked={scope === "jurisdiction"}
+                onChange={() => setScope("jurisdiction")}
+                className="accent-primary"
+              />
+              <span className="text-sm">By Jurisdiction</span>
+            </label>
+          </div>
+        </div>
+      )}
+
+      {(scope === "jurisdiction" || isLeaderOnly) && (
+        <div className="space-y-2">
+          <Label>City/Town</Label>
+          <ComboboxDropdown
+            items={cities.map((c) => ({ label: c, value: c }))}
+            initialValue={cityTown}
+            displayLabel="Select City/Town"
+            onSelect={handleCityChange}
+          />
+          {hasSubmitted && errors.cityTown && (
+            <p className="text-sm text-destructive">{errors.cityTown}</p>
+          )}
+        </div>
+      )}
+
+      {showLegDistrict && (
+        <div className="space-y-2">
+          <Label>Legislative District</Label>
+          <ComboboxDropdown
+            items={legDistricts.map((d) => ({
+              label: String(d),
+              value: String(d),
+            }))}
+            initialValue={legDistrict !== undefined ? String(legDistrict) : ""}
+            displayLabel="Select Legislative District"
+            onSelect={(v) => setLegDistrict(v ? Number(v) : undefined)}
+          />
+        </div>
+      )}
+
+      <div className="flex gap-4">
+        <div className="space-y-2 flex-1">
+          <Label htmlFor="dateFrom">Start Date</Label>
+          <Input
+            id="dateFrom"
+            type="date"
+            value={dateFrom}
+            onChange={(e) => setDateFrom(e.target.value)}
+          />
+          {hasSubmitted && errors.dateFrom && (
+            <p className="text-sm text-destructive">{errors.dateFrom}</p>
+          )}
+        </div>
+        <div className="space-y-2 flex-1">
+          <Label htmlFor="dateTo">End Date</Label>
+          <Input
+            id="dateTo"
+            type="date"
+            value={dateTo}
+            onChange={(e) => setDateTo(e.target.value)}
+          />
+          {hasSubmitted && errors.dateTo && (
+            <p className="text-sm text-destructive">{errors.dateTo}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Button
+          type="submit"
+          disabled={
+            generateReportMutation.loading ||
+            (hasSubmitted && Object.keys(errors).length > 0)
+          }
+        >
+          {generateReportMutation.loading ? "Generating..." : "Generate Report"}
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          Find your report in the{" "}
+          <Link href="/reports" className="text-blue-600 hover:text-blue-800 underline">
+            Reports page
+          </Link>
+        </p>
+      </div>
+
+      {generateReportMutation.loading && (
+        <div className="bg-primary-foreground p-4 rounded-lg flex items-center gap-2">
+          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary" />
+          <span>Generating changes report...</span>
+        </div>
+      )}
+
+      {reportId && (
+        <ReportStatusTracker
+          reportId={reportId}
+          onComplete={(url) => {
+            toast({ description: "Changes report generated!", duration: 5000 });
+            setReportUrl(url);
+            setReportId(null);
+          }}
+          onError={(msg) => {
+            toast({
+              variant: "destructive",
+              title: "Generation Failed",
+              description: msg || "Failed to generate changes report",
+              duration: 5000,
+            });
+            setReportId(null);
+          }}
+        />
+      )}
+
+      {reportUrl && (
+        <div className="space-y-4">
+          <p className="font-medium">Changes report generated successfully!</p>
+          <a
+            href={reportUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:text-blue-800 underline"
+          >
+            Open in New Tab
+          </a>
+        </div>
+      )}
+    </form>
+  );
+}

--- a/apps/frontend/src/app/changes-reports/page.tsx
+++ b/apps/frontend/src/app/changes-reports/page.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { auth } from "~/auth";
+import { hasPermissionFor } from "~/lib/utils";
+import { PrivilegeLevel, type CommitteeList } from "@prisma/client";
+import { Card, CardContent } from "~/components/ui/card";
+import prisma from "~/lib/prisma";
+import {
+  getActiveTermId,
+  getUserJurisdictions,
+  committeeMatchesJurisdictions,
+} from "~/app/api/lib/committeeValidation";
+import { ChangesReportForm } from "./ChangesReportForm";
+
+const ChangesReportsPage = async () => {
+  const permissions = await auth();
+
+  const privilegeLevel =
+    permissions?.user?.privilegeLevel ?? PrivilegeLevel.ReadAccess;
+
+  const isLeaderOrAbove = hasPermissionFor(
+    privilegeLevel,
+    PrivilegeLevel.Leader,
+  );
+
+  if (!isLeaderOrAbove) {
+    return (
+      <div className="w-full p-4">
+        <Card>
+          <CardContent className="pt-6">
+            <p>You do not have permission to access this page.</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const activeTermId = await getActiveTermId();
+
+  let committeeLists: CommitteeList[] = await prisma.committeeList.findMany({
+    where: { termId: activeTermId },
+  });
+
+  if (privilegeLevel === PrivilegeLevel.Leader && permissions?.user?.id) {
+    const jurisdictions = await getUserJurisdictions(
+      permissions.user.id,
+      activeTermId,
+      privilegeLevel,
+    );
+    if (Array.isArray(jurisdictions) && jurisdictions.length > 0) {
+      committeeLists = committeeLists.filter((c) =>
+        committeeMatchesJurisdictions(c.cityTown, c.legDistrict, jurisdictions),
+      );
+    } else {
+      committeeLists = [];
+    }
+  }
+
+  return (
+    <div className="w-full min-h-screen bg-primary-foreground">
+      <div className="max-w-6xl mx-auto p-4">
+        <div className="mb-6">
+          <h1 className="primary-header">Changes Report</h1>
+          <p className="text-muted-foreground mt-2">
+            Membership changes over a date range — additions, resignations,
+            removals, and petition outcomes.
+          </p>
+        </div>
+        <ChangesReportForm
+          committeeLists={committeeLists}
+          userPrivilegeLevel={privilegeLevel}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ChangesReportsPage;

--- a/apps/frontend/src/app/petition-outcomes-reports/PetitionOutcomesReportForm.tsx
+++ b/apps/frontend/src/app/petition-outcomes-reports/PetitionOutcomesReportForm.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import * as React from "react";
+import { useState, useMemo, useContext } from "react";
+import Link from "next/link";
+import { PrivilegeLevel, type CommitteeList } from "@prisma/client";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { useToast } from "~/components/ui/use-toast";
+import { ComboboxDropdown } from "~/components/ui/ComboBox";
+import { ReportStatusTracker } from "~/app/components/ReportStatusTracker";
+import { useApiMutation } from "~/hooks/useApiMutation";
+import { hasPermissionFor } from "~/lib/utils";
+import { GlobalContext } from "~/components/providers/GlobalContext";
+import type { GenerateReportData } from "@voter-file-tool/shared-validators";
+
+interface PetitionOutcomesReportFormProps {
+  committeeLists: CommitteeList[];
+  userPrivilegeLevel: PrivilegeLevel;
+}
+
+type Scope = "jurisdiction" | "countywide";
+
+function formatTodayDate(): string {
+  return new Date().toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function PetitionOutcomesReportForm({
+  committeeLists,
+  userPrivilegeLevel,
+}: PetitionOutcomesReportFormProps) {
+  const { toast } = useToast();
+  const { actingPermissions } = useContext(GlobalContext);
+
+  const effectivePrivilege = actingPermissions ?? userPrivilegeLevel;
+  const isAdmin = hasPermissionFor(effectivePrivilege, PrivilegeLevel.Admin);
+  const isLeaderOnly = !isAdmin;
+
+  const [name, setName] = useState(
+    `Petition Outcomes - ${formatTodayDate()}`,
+  );
+  const [format, setFormat] = useState<"pdf" | "xlsx">("xlsx");
+  const [scope, setScope] = useState<Scope>(
+    isLeaderOnly ? "jurisdiction" : "countywide",
+  );
+  const [cityTown, setCityTown] = useState("");
+  const [legDistrict, setLegDistrict] = useState<number | undefined>(undefined);
+  const [reportId, setReportId] = useState<string | null>(null);
+  const [reportUrl, setReportUrl] = useState<string | null>(null);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+
+  const cities = useMemo(() => {
+    const set = new Set(committeeLists.map((c) => c.cityTown));
+    return Array.from(set).sort();
+  }, [committeeLists]);
+
+  const legDistricts = useMemo(() => {
+    if (!cityTown) return [];
+    return Array.from(
+      new Set(
+        committeeLists
+          .filter((c) => c.cityTown === cityTown)
+          .map((c) => c.legDistrict),
+      ),
+    ).sort((a, b) => a - b);
+  }, [committeeLists, cityTown]);
+
+  const showLegDistrict =
+    cityTown.toUpperCase() === "ROCHESTER" && legDistricts.length > 1;
+
+  const generateReportMutation = useApiMutation<
+    { reportId: string },
+    GenerateReportData
+  >("/api/generateReport", "POST", {
+    onSuccess: (data) => {
+      setReportId(data.reportId);
+      toast({
+        title: "Report Generation Started",
+        description: "Your petition outcomes report is being generated.",
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: "Error",
+        description: `Failed to generate report: ${error instanceof Error ? error.message : "Unknown error"}`,
+        variant: "destructive",
+      });
+    },
+  });
+
+  function validate(): boolean {
+    const newErrors: Record<string, string> = {};
+    if (!name.trim()) newErrors.name = "Report name is required";
+    if (scope === "jurisdiction" && !cityTown) {
+      newErrors.cityTown = "City/Town selection is required for jurisdiction scope";
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }
+
+  const handleCityChange = (value: string) => {
+    setCityTown(value);
+    setLegDistrict(undefined);
+    if (value && errors.cityTown) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next.cityTown;
+        return next;
+      });
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setHasSubmitted(true);
+    if (!validate()) return;
+    setReportUrl(null);
+
+    const payload: GenerateReportData = {
+      type: "petitionOutcomesReport",
+      name: name.trim(),
+      format,
+      scope,
+      ...(scope === "jurisdiction" && cityTown ? { cityTown } : {}),
+      ...(scope === "jurisdiction" && legDistrict !== undefined
+        ? { legDistrict }
+        : {}),
+    };
+
+    await generateReportMutation.mutate(payload);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 max-w-2xl">
+      <div className="space-y-2">
+        <Label htmlFor="reportName">Report Name</Label>
+        <Input
+          id="reportName"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Enter report name"
+        />
+        {hasSubmitted && errors.name && (
+          <p className="text-sm text-destructive">{errors.name}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label>Format</Label>
+        <select
+          value={format}
+          onChange={(e) => setFormat(e.target.value as "pdf" | "xlsx")}
+          className="border rounded px-3 py-2 w-full max-w-[120px]"
+        >
+          <option value="pdf">PDF</option>
+          <option value="xlsx">XLSX</option>
+        </select>
+      </div>
+
+      {!isLeaderOnly && (
+        <div className="space-y-2">
+          <Label>Scope</Label>
+          <div className="flex gap-4">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                value="countywide"
+                checked={scope === "countywide"}
+                onChange={() => {
+                  setScope("countywide");
+                  setCityTown("");
+                  setLegDistrict(undefined);
+                }}
+                className="accent-primary"
+              />
+              <span className="text-sm">Countywide</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                value="jurisdiction"
+                checked={scope === "jurisdiction"}
+                onChange={() => setScope("jurisdiction")}
+                className="accent-primary"
+              />
+              <span className="text-sm">By Jurisdiction</span>
+            </label>
+          </div>
+        </div>
+      )}
+
+      {(scope === "jurisdiction" || isLeaderOnly) && (
+        <div className="space-y-2">
+          <Label>City/Town</Label>
+          <ComboboxDropdown
+            items={cities.map((c) => ({ label: c, value: c }))}
+            initialValue={cityTown}
+            displayLabel="Select City/Town"
+            onSelect={handleCityChange}
+          />
+          {hasSubmitted && errors.cityTown && (
+            <p className="text-sm text-destructive">{errors.cityTown}</p>
+          )}
+        </div>
+      )}
+
+      {showLegDistrict && (
+        <div className="space-y-2">
+          <Label>Legislative District</Label>
+          <ComboboxDropdown
+            items={legDistricts.map((d) => ({
+              label: String(d),
+              value: String(d),
+            }))}
+            initialValue={legDistrict !== undefined ? String(legDistrict) : ""}
+            displayLabel="Select Legislative District"
+            onSelect={(v) => setLegDistrict(v ? Number(v) : undefined)}
+          />
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button
+          type="submit"
+          disabled={
+            generateReportMutation.loading ||
+            (hasSubmitted && Object.keys(errors).length > 0)
+          }
+        >
+          {generateReportMutation.loading ? "Generating..." : "Generate Report"}
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          Find your report in the{" "}
+          <Link href="/reports" className="text-blue-600 hover:text-blue-800 underline">
+            Reports page
+          </Link>
+        </p>
+      </div>
+
+      {generateReportMutation.loading && (
+        <div className="bg-primary-foreground p-4 rounded-lg flex items-center gap-2">
+          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary" />
+          <span>Generating petition outcomes report...</span>
+        </div>
+      )}
+
+      {reportId && (
+        <ReportStatusTracker
+          reportId={reportId}
+          onComplete={(url) => {
+            toast({
+              description: "Petition outcomes report generated!",
+              duration: 5000,
+            });
+            setReportUrl(url);
+            setReportId(null);
+          }}
+          onError={(msg) => {
+            toast({
+              variant: "destructive",
+              title: "Generation Failed",
+              description: msg || "Failed to generate petition outcomes report",
+              duration: 5000,
+            });
+            setReportId(null);
+          }}
+        />
+      )}
+
+      {reportUrl && (
+        <div className="space-y-4">
+          <p className="font-medium">
+            Petition outcomes report generated successfully!
+          </p>
+          <a
+            href={reportUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:text-blue-800 underline"
+          >
+            Open in New Tab
+          </a>
+        </div>
+      )}
+    </form>
+  );
+}

--- a/apps/frontend/src/app/petition-outcomes-reports/page.tsx
+++ b/apps/frontend/src/app/petition-outcomes-reports/page.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { auth } from "~/auth";
+import { hasPermissionFor } from "~/lib/utils";
+import { PrivilegeLevel, type CommitteeList } from "@prisma/client";
+import { Card, CardContent } from "~/components/ui/card";
+import prisma from "~/lib/prisma";
+import {
+  getActiveTermId,
+  getUserJurisdictions,
+  committeeMatchesJurisdictions,
+} from "~/app/api/lib/committeeValidation";
+import { PetitionOutcomesReportForm } from "./PetitionOutcomesReportForm";
+
+const PetitionOutcomesReportsPage = async () => {
+  const permissions = await auth();
+
+  const privilegeLevel =
+    permissions?.user?.privilegeLevel ?? PrivilegeLevel.ReadAccess;
+
+  const isLeaderOrAbove = hasPermissionFor(
+    privilegeLevel,
+    PrivilegeLevel.Leader,
+  );
+
+  if (!isLeaderOrAbove) {
+    return (
+      <div className="w-full p-4">
+        <Card>
+          <CardContent className="pt-6">
+            <p>You do not have permission to access this page.</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const activeTermId = await getActiveTermId();
+
+  let committeeLists: CommitteeList[] = await prisma.committeeList.findMany({
+    where: { termId: activeTermId },
+  });
+
+  if (privilegeLevel === PrivilegeLevel.Leader && permissions?.user?.id) {
+    const jurisdictions = await getUserJurisdictions(
+      permissions.user.id,
+      activeTermId,
+      privilegeLevel,
+    );
+    if (Array.isArray(jurisdictions) && jurisdictions.length > 0) {
+      committeeLists = committeeLists.filter((c) =>
+        committeeMatchesJurisdictions(c.cityTown, c.legDistrict, jurisdictions),
+      );
+    } else {
+      committeeLists = [];
+    }
+  }
+
+  return (
+    <div className="w-full min-h-screen bg-primary-foreground">
+      <div className="max-w-6xl mx-auto p-4">
+        <div className="mb-6">
+          <h1 className="primary-header">Petition Outcomes Report</h1>
+          <p className="text-muted-foreground mt-2">
+            Petition results by committee and seat — winners, unopposed,
+            and outcomes.
+          </p>
+        </div>
+        <PetitionOutcomesReportForm
+          committeeLists={committeeLists}
+          userPrivilegeLevel={privilegeLevel}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PetitionOutcomesReportsPage;

--- a/apps/frontend/src/app/vacancy-reports/VacancyReportForm.tsx
+++ b/apps/frontend/src/app/vacancy-reports/VacancyReportForm.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import * as React from "react";
+import { useState, useMemo, useContext } from "react";
+import Link from "next/link";
+import { PrivilegeLevel, type CommitteeList } from "@prisma/client";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { useToast } from "~/components/ui/use-toast";
+import { ComboboxDropdown } from "~/components/ui/ComboBox";
+import { ReportStatusTracker } from "~/app/components/ReportStatusTracker";
+import { useApiMutation } from "~/hooks/useApiMutation";
+import { hasPermissionFor } from "~/lib/utils";
+import { GlobalContext } from "~/components/providers/GlobalContext";
+import type { GenerateReportData } from "@voter-file-tool/shared-validators";
+
+interface VacancyReportFormProps {
+  committeeLists: CommitteeList[];
+  userPrivilegeLevel: PrivilegeLevel;
+}
+
+type Scope = "jurisdiction" | "countywide";
+type VacancyFilter = "all" | "vacantOnly";
+
+function formatTodayDate(): string {
+  return new Date().toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function VacancyReportForm({
+  committeeLists,
+  userPrivilegeLevel,
+}: VacancyReportFormProps) {
+  const { toast } = useToast();
+  const { actingPermissions } = useContext(GlobalContext);
+
+  const effectivePrivilege = actingPermissions ?? userPrivilegeLevel;
+  const isAdmin = hasPermissionFor(effectivePrivilege, PrivilegeLevel.Admin);
+  const isLeaderOnly = !isAdmin;
+
+  const [name, setName] = useState(`Vacancy Report - ${formatTodayDate()}`);
+  const [format, setFormat] = useState<"pdf" | "xlsx">("xlsx");
+  const [scope, setScope] = useState<Scope>(
+    isLeaderOnly ? "jurisdiction" : "countywide",
+  );
+  const [cityTown, setCityTown] = useState("");
+  const [legDistrict, setLegDistrict] = useState<number | undefined>(undefined);
+  const [vacancyFilter, setVacancyFilter] = useState<VacancyFilter>("vacantOnly");
+  const [reportId, setReportId] = useState<string | null>(null);
+  const [reportUrl, setReportUrl] = useState<string | null>(null);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+
+  const cities = useMemo(() => {
+    const set = new Set(committeeLists.map((c) => c.cityTown));
+    return Array.from(set).sort();
+  }, [committeeLists]);
+
+  const legDistricts = useMemo(() => {
+    if (!cityTown) return [];
+    return Array.from(
+      new Set(
+        committeeLists
+          .filter((c) => c.cityTown === cityTown)
+          .map((c) => c.legDistrict),
+      ),
+    ).sort((a, b) => a - b);
+  }, [committeeLists, cityTown]);
+
+  const showLegDistrict =
+    cityTown.toUpperCase() === "ROCHESTER" && legDistricts.length > 1;
+
+  const generateReportMutation = useApiMutation<
+    { reportId: string },
+    GenerateReportData
+  >("/api/generateReport", "POST", {
+    onSuccess: (data) => {
+      setReportId(data.reportId);
+      toast({
+        title: "Report Generation Started",
+        description: "Your vacancy report is being generated.",
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: "Error",
+        description: `Failed to generate report: ${error instanceof Error ? error.message : "Unknown error"}`,
+        variant: "destructive",
+      });
+    },
+  });
+
+  function validate(): boolean {
+    const newErrors: Record<string, string> = {};
+    if (!name.trim()) newErrors.name = "Report name is required";
+    if (scope === "jurisdiction" && !cityTown) {
+      newErrors.cityTown = "City/Town selection is required for jurisdiction scope";
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }
+
+  const handleCityChange = (value: string) => {
+    setCityTown(value);
+    setLegDistrict(undefined);
+    if (value && errors.cityTown) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next.cityTown;
+        return next;
+      });
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setHasSubmitted(true);
+    if (!validate()) return;
+    setReportUrl(null);
+
+    const payload: GenerateReportData = {
+      type: "vacancyReport",
+      name: name.trim(),
+      format,
+      scope,
+      vacancyFilter,
+      ...(scope === "jurisdiction" && cityTown ? { cityTown } : {}),
+      ...(scope === "jurisdiction" && legDistrict !== undefined
+        ? { legDistrict }
+        : {}),
+    };
+
+    await generateReportMutation.mutate(payload);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 max-w-2xl">
+      <div className="space-y-2">
+        <Label htmlFor="reportName">Report Name</Label>
+        <Input
+          id="reportName"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Enter report name"
+        />
+        {hasSubmitted && errors.name && (
+          <p className="text-sm text-destructive">{errors.name}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label>Format</Label>
+        <select
+          value={format}
+          onChange={(e) => setFormat(e.target.value as "pdf" | "xlsx")}
+          className="border rounded px-3 py-2 w-full max-w-[120px]"
+        >
+          <option value="pdf">PDF</option>
+          <option value="xlsx">XLSX</option>
+        </select>
+      </div>
+
+      {!isLeaderOnly && (
+        <div className="space-y-2">
+          <Label>Scope</Label>
+          <div className="flex gap-4">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                value="countywide"
+                checked={scope === "countywide"}
+                onChange={() => {
+                  setScope("countywide");
+                  setCityTown("");
+                  setLegDistrict(undefined);
+                }}
+                className="accent-primary"
+              />
+              <span className="text-sm">Countywide</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                value="jurisdiction"
+                checked={scope === "jurisdiction"}
+                onChange={() => setScope("jurisdiction")}
+                className="accent-primary"
+              />
+              <span className="text-sm">By Jurisdiction</span>
+            </label>
+          </div>
+        </div>
+      )}
+
+      {(scope === "jurisdiction" || isLeaderOnly) && (
+        <div className="space-y-2">
+          <Label>City/Town</Label>
+          <ComboboxDropdown
+            items={cities.map((c) => ({ label: c, value: c }))}
+            initialValue={cityTown}
+            displayLabel="Select City/Town"
+            onSelect={handleCityChange}
+          />
+          {hasSubmitted && errors.cityTown && (
+            <p className="text-sm text-destructive">{errors.cityTown}</p>
+          )}
+        </div>
+      )}
+
+      {showLegDistrict && (
+        <div className="space-y-2">
+          <Label>Legislative District</Label>
+          <ComboboxDropdown
+            items={legDistricts.map((d) => ({
+              label: String(d),
+              value: String(d),
+            }))}
+            initialValue={legDistrict !== undefined ? String(legDistrict) : ""}
+            displayLabel="Select Legislative District"
+            onSelect={(v) => setLegDistrict(v ? Number(v) : undefined)}
+          />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label>Vacancy Filter</Label>
+        <div className="flex gap-4">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="vacancyFilter"
+              value="vacantOnly"
+              checked={vacancyFilter === "vacantOnly"}
+              onChange={() => setVacancyFilter("vacantOnly")}
+              className="accent-primary"
+            />
+            <span className="text-sm">Vacant only</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="vacancyFilter"
+              value="all"
+              checked={vacancyFilter === "all"}
+              onChange={() => setVacancyFilter("all")}
+              className="accent-primary"
+            />
+            <span className="text-sm">Show all</span>
+          </label>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Button
+          type="submit"
+          disabled={
+            generateReportMutation.loading ||
+            (hasSubmitted && Object.keys(errors).length > 0)
+          }
+        >
+          {generateReportMutation.loading ? "Generating..." : "Generate Report"}
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          Find your report in the{" "}
+          <Link href="/reports" className="text-blue-600 hover:text-blue-800 underline">
+            Reports page
+          </Link>
+        </p>
+      </div>
+
+      {generateReportMutation.loading && (
+        <div className="bg-primary-foreground p-4 rounded-lg flex items-center gap-2">
+          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary" />
+          <span>Generating vacancy report...</span>
+        </div>
+      )}
+
+      {reportId && (
+        <ReportStatusTracker
+          reportId={reportId}
+          onComplete={(url) => {
+            toast({ description: "Vacancy report generated!", duration: 5000 });
+            setReportUrl(url);
+            setReportId(null);
+          }}
+          onError={(msg) => {
+            toast({
+              variant: "destructive",
+              title: "Generation Failed",
+              description: msg || "Failed to generate vacancy report",
+              duration: 5000,
+            });
+            setReportId(null);
+          }}
+        />
+      )}
+
+      {reportUrl && (
+        <div className="space-y-4">
+          <p className="font-medium">Vacancy report generated successfully!</p>
+          <a
+            href={reportUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:text-blue-800 underline"
+          >
+            Open in New Tab
+          </a>
+        </div>
+      )}
+    </form>
+  );
+}

--- a/apps/frontend/src/app/vacancy-reports/page.tsx
+++ b/apps/frontend/src/app/vacancy-reports/page.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { auth } from "~/auth";
+import { hasPermissionFor } from "~/lib/utils";
+import { PrivilegeLevel, type CommitteeList } from "@prisma/client";
+import { Card, CardContent } from "~/components/ui/card";
+import prisma from "~/lib/prisma";
+import {
+  getActiveTermId,
+  getUserJurisdictions,
+  committeeMatchesJurisdictions,
+} from "~/app/api/lib/committeeValidation";
+import { VacancyReportForm } from "./VacancyReportForm";
+
+const VacancyReportsPage = async () => {
+  const permissions = await auth();
+
+  const privilegeLevel =
+    permissions?.user?.privilegeLevel ?? PrivilegeLevel.ReadAccess;
+
+  const isLeaderOrAbove = hasPermissionFor(
+    privilegeLevel,
+    PrivilegeLevel.Leader,
+  );
+
+  if (!isLeaderOrAbove) {
+    return (
+      <div className="w-full p-4">
+        <Card>
+          <CardContent className="pt-6">
+            <p>You do not have permission to access this page.</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const activeTermId = await getActiveTermId();
+
+  let committeeLists: CommitteeList[] = await prisma.committeeList.findMany({
+    where: { termId: activeTermId },
+  });
+
+  if (privilegeLevel === PrivilegeLevel.Leader && permissions?.user?.id) {
+    const jurisdictions = await getUserJurisdictions(
+      permissions.user.id,
+      activeTermId,
+      privilegeLevel,
+    );
+    if (Array.isArray(jurisdictions) && jurisdictions.length > 0) {
+      committeeLists = committeeLists.filter((c) =>
+        committeeMatchesJurisdictions(c.cityTown, c.legDistrict, jurisdictions),
+      );
+    } else {
+      committeeLists = [];
+    }
+  }
+
+  return (
+    <div className="w-full min-h-screen bg-primary-foreground">
+      <div className="max-w-6xl mx-auto p-4">
+        <div className="mb-6">
+          <h1 className="primary-header">Vacancy Report</h1>
+          <p className="text-muted-foreground mt-2">
+            Committee vacancies with seat counts and petitioned status.
+          </p>
+        </div>
+        <VacancyReportForm
+          committeeLists={committeeLists}
+          userPrivilegeLevel={privilegeLevel}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default VacancyReportsPage;

--- a/apps/frontend/src/components/reports/GenerateReportGrid.tsx
+++ b/apps/frontend/src/components/reports/GenerateReportGrid.tsx
@@ -54,20 +54,20 @@ const reportTypes: ReportType[] = [
   {
     title: "Vacancy Report",
     description: "Committee vacancies with optional filters",
-    href: "/reports/vacancy",
-    enabled: false,
+    href: "/vacancy-reports",
+    enabled: true,
   },
   {
     title: "Changes Report",
     description: "Membership changes over a date range",
-    href: "/reports/changes",
-    enabled: false,
+    href: "/changes-reports",
+    enabled: true,
   },
   {
     title: "Petition Outcomes",
-    description: "Petition results by term and date range",
-    href: "/reports/petition-outcomes",
-    enabled: false,
+    description: "Petition results by committee and seat",
+    href: "/petition-outcomes-reports",
+    enabled: true,
   },
 ];
 

--- a/apps/frontend/src/types/reportMetadata.ts
+++ b/apps/frontend/src/types/reportMetadata.ts
@@ -14,6 +14,9 @@ export type ReportMetadataMap = {
   [ReportType.AbsenteeReport]: null;
   [ReportType.SignInSheet]: null;
   [ReportType.DesignationWeightSummary]: null;
+  [ReportType.VacancyReport]: null;
+  [ReportType.ChangesReport]: null;
+  [ReportType.PetitionOutcomesReport]: null;
 };
 
 // Helper type to get metadata for a specific report type

--- a/apps/report-server/src/__tests__/committeeMappingHelpers.test.ts
+++ b/apps/report-server/src/__tests__/committeeMappingHelpers.test.ts
@@ -3,6 +3,10 @@ import {
   fetchCommitteeData,
   fetchSignInSheetData,
   fetchDesignationWeights,
+  fetchVacancyData,
+  fetchChangesData,
+  fetchPetitionOutcomesData,
+  getPetitionOutcomeLabel,
   mapCommitteesToReportShape,
   type CommitteeWithMembers,
 } from '../committeeMappingHelpers';
@@ -16,16 +20,20 @@ jest.mock('../lib/prisma', () => ({
     committeeList: {
       findMany: jest.fn(),
     },
+    committeeGovernanceConfig: {
+      findFirst: jest.fn(),
+    },
+    committeeMembership: {
+      findMany: jest.fn(),
+    },
   },
 }));
 
 type MockPrisma = {
-  committeeTerm: {
-    findFirst: jest.Mock;
-  };
-  committeeList: {
-    findMany: jest.Mock;
-  };
+  committeeTerm: { findFirst: jest.Mock };
+  committeeList: { findMany: jest.Mock };
+  committeeGovernanceConfig: { findFirst: jest.Mock };
+  committeeMembership: { findMany: jest.Mock };
 };
 
 const prismaMock = prisma as unknown as MockPrisma;
@@ -481,5 +489,133 @@ describe('computeDesignationWeight', () => {
         ],
       } as unknown as CommitteeWithMembers),
     ).toThrow(/Data integrity error: duplicate active memberships/);
+  });
+});
+
+describe('fetchVacancyData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws when scope is jurisdiction and cityTown is empty', async () => {
+    prismaMock.committeeTerm.findFirst.mockResolvedValue({ id: 'term-1' });
+
+    await expect(
+      fetchVacancyData('jurisdiction', 'vacantOnly', ''),
+    ).rejects.toThrow(/cityTown is required when scope is jurisdiction/);
+    expect(prismaMock.committeeList.findMany).not.toHaveBeenCalled();
+  });
+
+  it('fetches committees with seats and memberships when scope is countywide', async () => {
+    prismaMock.committeeTerm.findFirst.mockResolvedValue({ id: 'term-1' });
+    prismaMock.committeeGovernanceConfig.findFirst.mockResolvedValue({
+      maxSeatsPerLted: 4,
+    });
+    prismaMock.committeeList.findMany.mockResolvedValue([
+      {
+        id: 1,
+        cityTown: 'ROCHESTER',
+        legDistrict: 1,
+        electionDistrict: 42,
+        termId: 'term-1',
+        seats: [
+          { seatNumber: 1, isPetitioned: false },
+          { seatNumber: 2, isPetitioned: false },
+          { seatNumber: 3, isPetitioned: true },
+          { seatNumber: 4, isPetitioned: true },
+        ],
+        memberships: [
+          { seatNumber: 1, voterRecord: {} },
+          { seatNumber: 2, voterRecord: {} },
+          { seatNumber: 3, voterRecord: {} },
+        ],
+      },
+    ]);
+
+    const rows = await fetchVacancyData('countywide', 'all');
+
+    expect(prismaMock.committeeList.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { termId: 'term-1' },
+        include: expect.objectContaining({
+          seats: expect.any(Object),
+          memberships: expect.any(Object),
+        }),
+        orderBy: [
+          { cityTown: 'asc' },
+          { legDistrict: 'asc' },
+          { electionDistrict: 'asc' },
+        ],
+      }),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      cityTown: 'ROCHESTER',
+      legDistrict: 1,
+      electionDistrict: 42,
+      totalSeats: 4,
+      filledSeats: 3,
+      vacantSeats: 1,
+    });
+  });
+});
+
+describe('fetchChangesData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws when dateFrom or dateTo is invalid', async () => {
+    prismaMock.committeeTerm.findFirst.mockResolvedValue({ id: 'term-1' });
+
+    await expect(
+      fetchChangesData('countywide', 'invalid', '2025-01-15'),
+    ).rejects.toThrow(/Invalid dateFrom or dateTo/);
+    await expect(
+      fetchChangesData('countywide', '2025-01-15', '2025-01-01'),
+    ).rejects.toThrow(/dateFrom must be <= dateTo/);
+  });
+
+  it('throws when scope is jurisdiction and cityTown is empty', async () => {
+    prismaMock.committeeTerm.findFirst.mockResolvedValue({ id: 'term-1' });
+
+    await expect(
+      fetchChangesData('jurisdiction', '2025-01-01', '2025-01-31', ''),
+    ).rejects.toThrow(/cityTown is required when scope is jurisdiction/);
+  });
+});
+
+describe('fetchPetitionOutcomesData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws when scope is jurisdiction and cityTown is empty', async () => {
+    prismaMock.committeeTerm.findFirst.mockResolvedValue({ id: 'term-1' });
+
+    await expect(
+      fetchPetitionOutcomesData('jurisdiction', ''),
+    ).rejects.toThrow(/cityTown is required when scope is jurisdiction/);
+  });
+});
+
+describe('getPetitionOutcomeLabel', () => {
+  it('returns Lost for PETITIONED_LOST', () => {
+    expect(getPetitionOutcomeLabel('PETITIONED_LOST', 'PETITIONED', 2)).toBe(
+      'Lost',
+    );
+  });
+  it('returns Tie for PETITIONED_TIE', () => {
+    expect(getPetitionOutcomeLabel('PETITIONED_TIE', 'PETITIONED', 2)).toBe(
+      'Tie',
+    );
+  });
+  it('returns Unopposed when ACTIVE and single candidate', () => {
+    expect(getPetitionOutcomeLabel('ACTIVE', 'PETITIONED', 1)).toBe(
+      'Unopposed',
+    );
+  });
+  it('returns Won when ACTIVE and multiple candidates', () => {
+    expect(getPetitionOutcomeLabel('ACTIVE', 'PETITIONED', 3)).toBe('Won');
   });
 });

--- a/apps/report-server/src/committeeMappingHelpers.ts
+++ b/apps/report-server/src/committeeMappingHelpers.ts
@@ -344,3 +344,368 @@ export async function fetchDesignationWeights(
 
   return committees.map(computeDesignationWeight);
 }
+
+// ---------------------------------------------------------------------------
+// SRS 3.4 — Vacancy, Changes, and Petition Outcomes report data fetchers
+// ---------------------------------------------------------------------------
+
+export type VacancyReportRow = {
+  cityTown: string;
+  legDistrict: number;
+  electionDistrict: number;
+  totalSeats: number;
+  filledSeats: number;
+  vacantSeats: number;
+  petitionedSeats: number;
+  vacantPetitionedSeats: number;
+  nonPetitionedSeats: number;
+};
+
+/**
+ * Fetches vacancy data for committees. Compares maxSeatsPerLted to active membership count.
+ */
+export async function fetchVacancyData(
+  scope: 'jurisdiction' | 'countywide',
+  vacancyFilter: 'all' | 'vacantOnly',
+  cityTown?: string,
+  legDistrict?: number,
+): Promise<VacancyReportRow[]> {
+  const activeTermId = await getActiveTermId();
+  const config = await prisma.committeeGovernanceConfig.findFirst();
+  const maxSeatsPerLted = config?.maxSeatsPerLted ?? 4;
+
+  const where: Parameters<typeof prisma.committeeList.findMany>[0]['where'] = {
+    termId: activeTermId,
+  };
+  if (scope === 'jurisdiction') {
+    if (cityTown == null || cityTown === '') {
+      throw new Error('cityTown is required when scope is jurisdiction');
+    }
+    where.cityTown = cityTown;
+    if (legDistrict != null) {
+      where.legDistrict = legDistrict;
+    }
+  }
+
+  const committees = await prisma.committeeList.findMany({
+    where,
+    include: {
+      seats: { orderBy: { seatNumber: 'asc' } },
+      memberships: {
+        where: { termId: activeTermId, status: 'ACTIVE' },
+        include: { voterRecord: true },
+      },
+    },
+    orderBy: [
+      { cityTown: 'asc' },
+      { legDistrict: 'asc' },
+      { electionDistrict: 'asc' },
+    ],
+  });
+
+  const rows: VacancyReportRow[] = [];
+
+  for (const cl of committees) {
+    const seats = cl.seats ?? [];
+    const activeMemberships = cl.memberships ?? [];
+    const filledSeats = activeMemberships.filter((m) => m.seatNumber != null).length;
+    const totalSeats = maxSeatsPerLted;
+    const vacantSeats = totalSeats - filledSeats;
+
+    const petitionedSeats = seats.filter((s) => s.isPetitioned).length;
+    const occupiedPetitionedSeats = activeMemberships.filter(
+      (m) => m.seatNumber != null && seats.some((s) => s.seatNumber === m.seatNumber && s.isPetitioned),
+    ).length;
+    const vacantPetitionedSeats = petitionedSeats - occupiedPetitionedSeats;
+    const nonPetitionedSeats = totalSeats - petitionedSeats;
+
+    if (vacancyFilter === 'vacantOnly' && vacantSeats === 0) continue;
+
+    rows.push({
+      cityTown: cl.cityTown,
+      legDistrict: cl.legDistrict,
+      electionDistrict: cl.electionDistrict,
+      totalSeats,
+      filledSeats,
+      vacantSeats,
+      petitionedSeats,
+      vacantPetitionedSeats,
+      nonPetitionedSeats,
+    });
+  }
+
+  return rows;
+}
+
+export type ChangesReportRow = {
+  memberName: string;
+  cityTown: string;
+  legDistrict: number;
+  electionDistrict: number;
+  changeType: 'Added' | 'Resigned' | 'Removed' | 'Confirmed' | 'Petition Won' | 'Petition Lost';
+  changeDate: string;
+  details: string;
+};
+
+/**
+ * Fetches committee membership changes within a date range.
+ */
+export async function fetchChangesData(
+  scope: 'jurisdiction' | 'countywide',
+  dateFrom: string,
+  dateTo: string,
+  cityTown?: string,
+  legDistrict?: number,
+): Promise<ChangesReportRow[]> {
+  const activeTermId = await getActiveTermId();
+  const fromDate = new Date(dateFrom);
+  const toDate = new Date(dateTo);
+  if (Number.isNaN(fromDate.getTime()) || Number.isNaN(toDate.getTime())) {
+    throw new Error('Invalid dateFrom or dateTo');
+  }
+  if (fromDate > toDate) {
+    throw new Error('dateFrom must be <= dateTo');
+  }
+
+  const rows: ChangesReportRow[] = [];
+
+  const membershipWhere: Parameters<typeof prisma.committeeMembership.findMany>[0]['where'] = {
+    termId: activeTermId,
+    OR: [
+      { activatedAt: { gte: fromDate, lte: toDate } },
+      { resignedAt: { gte: fromDate, lte: toDate } },
+      { removedAt: { gte: fromDate, lte: toDate } },
+      { confirmedAt: { gte: fromDate, lte: toDate } },
+      { petitionPrimaryDate: { gte: fromDate, lte: toDate } },
+    ],
+  };
+
+  const memberships = await prisma.committeeMembership.findMany({
+    where: membershipWhere,
+    include: {
+      voterRecord: true,
+      committeeList: true,
+    },
+  });
+
+  const committeeWhere: Parameters<typeof prisma.committeeList.findMany>[0]['where'] = {};
+  if (scope === 'jurisdiction') {
+    if (cityTown == null || cityTown === '') {
+      throw new Error('cityTown is required when scope is jurisdiction');
+    }
+    committeeWhere.cityTown = cityTown;
+    if (legDistrict != null) {
+      committeeWhere.legDistrict = legDistrict;
+    }
+  }
+
+  for (const m of memberships) {
+    const cl = m.committeeList;
+    if (scope === 'jurisdiction') {
+      if (cl.cityTown !== cityTown) continue;
+      if (legDistrict != null && cl.legDistrict !== legDistrict) continue;
+    }
+
+    const name = [m.voterRecord.firstName, m.voterRecord.lastName].filter(Boolean).join(' ') || m.voterRecord.VRCNUM;
+    const cityTownVal = cl.cityTown;
+    const legDistrictVal = cl.legDistrict;
+    const electionDistrict = cl.electionDistrict;
+
+    const candidates: { changeType: ChangesReportRow['changeType']; changeDate: Date; details: string }[] = [];
+
+    if (m.activatedAt && m.activatedAt >= fromDate && m.activatedAt <= toDate) {
+      const changeType: ChangesReportRow['changeType'] =
+        m.membershipType === 'PETITIONED' ? 'Petition Won' : 'Added';
+      candidates.push({
+        changeType,
+        changeDate: m.activatedAt,
+        details: changeType === 'Petition Won' && m.petitionVoteCount != null
+          ? `${m.petitionVoteCount} votes`
+          : '',
+      });
+    }
+    if (m.resignedAt && m.resignedAt >= fromDate && m.resignedAt <= toDate) {
+      const details = m.resignationMethod ? `Method: ${m.resignationMethod}` : '';
+      candidates.push({ changeType: 'Resigned', changeDate: m.resignedAt, details });
+    }
+    if (m.removedAt && m.removedAt >= fromDate && m.removedAt <= toDate) {
+      const details = [m.removalReason, m.removalNotes].filter(Boolean).join(' — ') || '';
+      candidates.push({ changeType: 'Removed', changeDate: m.removedAt, details });
+    }
+    if (m.confirmedAt && m.confirmedAt >= fromDate && m.confirmedAt <= toDate) {
+      candidates.push({ changeType: 'Confirmed', changeDate: m.confirmedAt, details: '' });
+    }
+    if (
+      (m.status === 'PETITIONED_LOST' || m.status === 'PETITIONED_TIE') &&
+      m.petitionPrimaryDate &&
+      m.petitionPrimaryDate >= fromDate &&
+      m.petitionPrimaryDate <= toDate
+    ) {
+      const details = m.petitionVoteCount != null
+        ? `${m.petitionVoteCount} votes`
+        : m.status === 'PETITIONED_TIE'
+          ? 'Tie'
+          : '';
+      candidates.push({
+        changeType: 'Petition Lost',
+        changeDate: m.petitionPrimaryDate,
+        details,
+      });
+    }
+
+    for (const c of candidates) {
+      rows.push({
+        memberName: name,
+        cityTown: cityTownVal,
+        legDistrict: legDistrictVal,
+        electionDistrict,
+        changeType: c.changeType,
+        changeDate: c.changeDate.toISOString().slice(0, 10),
+        details: c.details,
+      });
+    }
+  }
+
+  rows.sort((a, b) => (b.changeDate === a.changeDate ? 0 : b.changeDate > a.changeDate ? 1 : -1));
+  return rows;
+}
+
+export type PetitionOutcomeRow = {
+  committeeListId: number;
+  cityTown: string;
+  legDistrict: number;
+  electionDistrict: number;
+  seatNumber: number;
+  candidateName: string;
+  voteCount: number | null;
+  outcome: 'Won' | 'Unopposed' | 'Lost' | 'Tie';
+  primaryDate: string | null;
+};
+
+/**
+ * Maps MembershipStatus + seat candidate count to human-readable outcome label.
+ */
+export function getPetitionOutcomeLabel(
+  status: string,
+  membershipType: string | null,
+  seatCandidateCount: number,
+): 'Won' | 'Unopposed' | 'Lost' | 'Tie' {
+  if (status === 'PETITIONED_LOST') return 'Lost';
+  if (status === 'PETITIONED_TIE') return 'Tie';
+  if (status === 'ACTIVE' && membershipType === 'PETITIONED') {
+    return seatCandidateCount === 1 ? 'Unopposed' : 'Won';
+  }
+  return 'Lost';
+}
+
+/**
+ * Fetches petition outcome data for report generation.
+ */
+export async function fetchPetitionOutcomesData(
+  scope: 'jurisdiction' | 'countywide',
+  cityTown?: string,
+  legDistrict?: number,
+): Promise<PetitionOutcomeRow[]> {
+  const activeTermId = await getActiveTermId();
+
+  const committeeWhere: Parameters<typeof prisma.committeeList.findMany>[0]['where'] = {
+    termId: activeTermId,
+  };
+  if (scope === 'jurisdiction') {
+    if (cityTown == null || cityTown === '') {
+      throw new Error('cityTown is required when scope is jurisdiction');
+    }
+    committeeWhere.cityTown = cityTown;
+    if (legDistrict != null) {
+      committeeWhere.legDistrict = legDistrict;
+    }
+  }
+
+  const memberships = await prisma.committeeMembership.findMany({
+    where: {
+      termId: activeTermId,
+      membershipType: 'PETITIONED',
+      petitionSeatNumber: { not: null },
+    },
+    include: {
+      voterRecord: true,
+      committeeList: true,
+    },
+  });
+
+  const petBySeat = new Map<string, (typeof memberships)[0][]>();
+  for (const m of memberships) {
+    if (m.petitionSeatNumber == null) continue;
+    const cl = m.committeeList;
+    if (scope === 'jurisdiction') {
+      if (cl.cityTown !== cityTown) continue;
+      if (legDistrict != null && cl.legDistrict !== legDistrict) continue;
+    }
+    const key = `${cl.id}|${m.termId}|${m.petitionSeatNumber}`;
+    const list = petBySeat.get(key) ?? [];
+    list.push(m);
+    petBySeat.set(key, list);
+  }
+
+  const lostOrTie = await prisma.committeeMembership.findMany({
+    where: {
+      termId: activeTermId,
+      membershipType: 'PETITIONED',
+      status: { in: ['PETITIONED_LOST', 'PETITIONED_TIE'] },
+    },
+    include: {
+      voterRecord: true,
+      committeeList: true,
+    },
+  });
+
+  // PETITIONED_LOST memberships have petitionSeatNumber === null (per ticket: "Lost primary; seatNumber is null").
+  // Group them under synthetic seat 0 for display.
+  for (const m of lostOrTie) {
+    const cl = m.committeeList;
+    if (scope === 'jurisdiction') {
+      if (cl.cityTown !== cityTown) continue;
+      if (legDistrict != null && cl.legDistrict !== legDistrict) continue;
+    }
+    const seatNum = m.petitionSeatNumber ?? 0;
+    const key = `${cl.id}|${m.termId}|${seatNum}`;
+    const list = petBySeat.get(key) ?? [];
+    list.push(m);
+    petBySeat.set(key, list);
+  }
+
+  const rows: PetitionOutcomeRow[] = [];
+
+  for (const [, candidates] of petBySeat) {
+    if (candidates.length === 0) continue;
+    const first = candidates[0];
+    const cl = first.committeeList;
+    const seatNum = first.petitionSeatNumber ?? candidates.find((c) => c.petitionSeatNumber != null)?.petitionSeatNumber ?? 0;
+    const count = candidates.length;
+
+    for (const m of candidates) {
+      const name = [m.voterRecord.firstName, m.voterRecord.lastName].filter(Boolean).join(' ') || m.voterRecord.VRCNUM;
+      const outcome = getPetitionOutcomeLabel(m.status, m.membershipType ?? null, count);
+      rows.push({
+        committeeListId: cl.id,
+        cityTown: cl.cityTown,
+        legDistrict: cl.legDistrict,
+        electionDistrict: cl.electionDistrict,
+        seatNumber: seatNum,
+        candidateName: name,
+        voteCount: m.petitionVoteCount,
+        outcome,
+        primaryDate: m.petitionPrimaryDate ? m.petitionPrimaryDate.toISOString().slice(0, 10) : null,
+      });
+    }
+  }
+
+  rows.sort((a, b) => {
+    if (a.cityTown !== b.cityTown) return a.cityTown.localeCompare(b.cityTown);
+    if (a.legDistrict !== b.legDistrict) return a.legDistrict - b.legDistrict;
+    if (a.electionDistrict !== b.electionDistrict) return a.electionDistrict - b.electionDistrict;
+    return a.seatNumber - b.seatNumber;
+  });
+
+  return rows;
+}

--- a/apps/report-server/src/components/ChangesReport.tsx
+++ b/apps/report-server/src/components/ChangesReport.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import type { ChangesReportRow } from '../committeeMappingHelpers';
+
+interface ChangesReportProps {
+  rows: ChangesReportRow[];
+  dateFrom: string;
+  dateTo: string;
+  reportAuthor: string;
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * Changes report PDF — table with Date, Member Name, City/Town, LD, ED, Change Type, Details.
+ * Grouped by date (descending).
+ */
+function ChangesReport({ rows, dateFrom, dateTo, reportAuthor }: ChangesReportProps) {
+    const byDate = new Map<string, ChangesReportRow[]>();
+    for (const r of rows) {
+      const list = byDate.get(r.changeDate) ?? [];
+      list.push(r);
+      byDate.set(r.changeDate, list);
+    }
+    const sortedDates = Array.from(byDate.keys()).sort((a, b) => (b > a ? 1 : -1));
+
+    const fromFmt = formatDate(dateFrom);
+    const toFmt = formatDate(dateTo);
+    const generationDate = new Date().toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+
+    return (
+      <div className="w-[8.5in] min-h-[11in] p-6 font-sans bg-white" style={{ fontFamily: 'Arial, sans-serif' }}>
+        <h1 className="text-xl font-bold mb-2">Committee Changes</h1>
+        <p className="text-sm mb-4">
+          {fromFmt} — {toFmt}
+        </p>
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="border border-gray-400 px-2 py-1 text-left">Date</th>
+              <th className="border border-gray-400 px-2 py-1 text-left">Member Name</th>
+              <th className="border border-gray-400 px-2 py-1 text-left">City/Town</th>
+              <th className="border border-gray-400 px-2 py-1 text-right">LD</th>
+              <th className="border border-gray-400 px-2 py-1 text-right">ED</th>
+              <th className="border border-gray-400 px-2 py-1 text-left">Change Type</th>
+              <th className="border border-gray-400 px-2 py-1 text-left">Details</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedDates.map((dateStr) => {
+              const dateRows = (byDate.get(dateStr) ?? []).sort(
+                (a, b) =>
+                  a.changeType.localeCompare(b.changeType) ||
+                  a.memberName.localeCompare(b.memberName),
+              );
+              const dateFmt = formatDate(dateStr);
+              return dateRows.map((r, i) => (
+                <tr key={`${dateStr}-${r.memberName}-${r.electionDistrict}-${i}`}>
+                  <td className="border border-gray-400 px-2 py-1">{dateFmt}</td>
+                  <td className="border border-gray-400 px-2 py-1">{r.memberName}</td>
+                  <td className="border border-gray-400 px-2 py-1">{r.cityTown}</td>
+                  <td className="border border-gray-400 px-2 py-1 text-right">{r.legDistrict}</td>
+                  <td className="border border-gray-400 px-2 py-1 text-right">{r.electionDistrict}</td>
+                  <td className="border border-gray-400 px-2 py-1">{r.changeType}</td>
+                  <td className="border border-gray-400 px-2 py-1">{r.details}</td>
+                </tr>
+              ));
+            })}
+          </tbody>
+        </table>
+        <div className="mt-4 flex justify-between text-xs">
+          <span>{generationDate}</span>
+          <span>{reportAuthor}</span>
+        </div>
+      </div>
+    );
+}
+
+ChangesReport.displayName = 'ChangesReport';
+export default ChangesReport;

--- a/apps/report-server/src/components/PetitionOutcomesReport.tsx
+++ b/apps/report-server/src/components/PetitionOutcomesReport.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import type { PetitionOutcomeRow } from '../committeeMappingHelpers';
+
+interface PetitionOutcomesReportProps {
+  rows: PetitionOutcomeRow[];
+  reportAuthor: string;
+}
+
+/** Groups petition outcome rows by committee (cityTown, legDistrict, electionDistrict) */
+function groupByCommittee(
+  rows: PetitionOutcomeRow[],
+): { cityTown: string; legDistrict: number; electionDistrict: number; rows: PetitionOutcomeRow[] }[] {
+  const map = new Map<
+    string,
+    { cityTown: string; legDistrict: number; electionDistrict: number; rows: PetitionOutcomeRow[] }
+  >();
+  for (const r of rows) {
+    const key = `${r.cityTown}|${r.legDistrict}|${r.electionDistrict}`;
+    const existing = map.get(key);
+    if (existing) {
+      existing.rows.push(r);
+    } else {
+      map.set(key, {
+        cityTown: r.cityTown,
+        legDistrict: r.legDistrict,
+        electionDistrict: r.electionDistrict,
+        rows: [r],
+      });
+    }
+  }
+  return Array.from(map.values()).sort(
+    (a, b) =>
+      a.cityTown.localeCompare(b.cityTown) ||
+      a.legDistrict - b.legDistrict ||
+      a.electionDistrict - b.electionDistrict,
+  );
+}
+
+function rowBgClass(outcome: PetitionOutcomeRow['outcome']): string {
+  if (outcome === 'Won' || outcome === 'Unopposed') return 'bg-green-100';
+  if (outcome === 'Tie') return 'bg-amber-100';
+  return '';
+}
+
+/**
+ * Petition outcomes PDF — landscape table grouped by committee.
+ * Color: Won/Unopposed = green, Tie = amber, Lost = default.
+ */
+function PetitionOutcomesReport({ rows, reportAuthor }: PetitionOutcomesReportProps) {
+    const groups = groupByCommittee(rows);
+    const generationDate = new Date().toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+
+    return (
+      <div className="w-[11in] min-h-[8.5in] p-6 font-sans bg-white" style={{ fontFamily: 'Arial, sans-serif' }}>
+        <h1 className="text-xl font-bold mb-4">Petition Outcomes Report</h1>
+        {groups.map((g) => (
+          <div key={`${g.cityTown}-${g.legDistrict}-${g.electionDistrict}`} className="mb-6">
+            <h2 className="text-sm font-semibold mb-2">
+              City/Town: {g.cityTown}, LD {g.legDistrict}, ED {g.electionDistrict}
+            </h2>
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="border border-gray-400 px-2 py-1 text-right">Seat #</th>
+                  <th className="border border-gray-400 px-2 py-1 text-left">Candidate Name</th>
+                  <th className="border border-gray-400 px-2 py-1 text-right">Vote Count</th>
+                  <th className="border border-gray-400 px-2 py-1 text-left">Outcome</th>
+                  <th className="border border-gray-400 px-2 py-1 text-left">Primary Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {g.rows.map((r, i) => (
+                  <tr key={i} className={rowBgClass(r.outcome)}>
+                    <td className="border border-gray-400 px-2 py-1 text-right">{r.seatNumber}</td>
+                    <td className="border border-gray-400 px-2 py-1">{r.candidateName}</td>
+                    <td className="border border-gray-400 px-2 py-1 text-right">
+                      {r.voteCount != null ? r.voteCount : '—'}
+                    </td>
+                    <td className="border border-gray-400 px-2 py-1">{r.outcome}</td>
+                    <td className="border border-gray-400 px-2 py-1">{r.primaryDate ?? '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ))}
+        <div className="mt-4 flex justify-between text-xs">
+          <span>{generationDate}</span>
+          <span>{reportAuthor}</span>
+        </div>
+      </div>
+    );
+}
+
+PetitionOutcomesReport.displayName = 'PetitionOutcomesReport';
+export default PetitionOutcomesReport;

--- a/apps/report-server/src/components/VacancyReport.tsx
+++ b/apps/report-server/src/components/VacancyReport.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import type { VacancyReportRow } from '../committeeMappingHelpers';
+
+interface VacancyReportProps {
+  rows: VacancyReportRow[];
+  reportAuthor: string;
+}
+
+/** Groups vacancy rows by cityTown + legDistrict for subtotals */
+function groupByCityLd(
+  rows: VacancyReportRow[],
+): { key: string; cityTown: string; legDistrict: number; rows: VacancyReportRow[] }[] {
+  const map = new Map<string, { cityTown: string; legDistrict: number; rows: VacancyReportRow[] }>();
+  for (const r of rows) {
+    const key = `${r.cityTown}|${r.legDistrict}`;
+    const existing = map.get(key);
+    if (existing) {
+      existing.rows.push(r);
+    } else {
+      map.set(key, { cityTown: r.cityTown, legDistrict: r.legDistrict, rows: [r] });
+    }
+  }
+  return Array.from(map.values()).sort(
+    (a, b) =>
+      a.cityTown.localeCompare(b.cityTown) || a.legDistrict - b.legDistrict,
+  );
+}
+
+/**
+ * Vacancy report PDF — landscape table grouped by city/LD with subtotals and grand total.
+ */
+function VacancyReport({ rows, reportAuthor }: VacancyReportProps) {
+    const groups = groupByCityLd(rows);
+    const generationDate = new Date().toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+
+    let grandTotalSeats = 0;
+    let grandFilled = 0;
+    let grandVacant = 0;
+    let grandPetitioned = 0;
+    let grandVacantPetitioned = 0;
+    let grandNonPetitioned = 0;
+
+    for (const r of rows) {
+      grandTotalSeats += r.totalSeats;
+      grandFilled += r.filledSeats;
+      grandVacant += r.vacantSeats;
+      grandPetitioned += r.petitionedSeats;
+      grandVacantPetitioned += r.vacantPetitionedSeats;
+      grandNonPetitioned += r.nonPetitionedSeats;
+    }
+
+    return (
+      <div className="w-[11in] h-[8.5in] p-6 font-sans bg-white" style={{ fontFamily: 'Arial, sans-serif' }}>
+        <h1 className="text-xl font-bold mb-4">Vacancy Report</h1>
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="border border-gray-400 px-2 py-1 text-left">ED</th>
+              <th className="border border-gray-400 px-2 py-1 text-right">Total Seats</th>
+              <th className="border border-gray-400 px-2 py-1 text-right">Filled</th>
+              <th className="border border-gray-400 px-2 py-1 text-right">Vacant</th>
+              <th className="border border-gray-400 px-2 py-1 text-right">Petitioned (Filled)</th>
+              <th className="border border-gray-400 px-2 py-1 text-right">Petitioned (Vacant)</th>
+              <th className="border border-gray-400 px-2 py-1 text-right">Non-Petitioned</th>
+            </tr>
+          </thead>
+          <tbody>
+            {groups.map((g) => {
+              let subTotal = 0;
+              let subFilled = 0;
+              let subVacant = 0;
+              let subPetitioned = 0;
+              let subVacantPetitioned = 0;
+              let subNonPetitioned = 0;
+              for (const r of g.rows) {
+                subTotal += r.totalSeats;
+                subFilled += r.filledSeats;
+                subVacant += r.vacantSeats;
+                subPetitioned += r.petitionedSeats;
+                subVacantPetitioned += r.vacantPetitionedSeats;
+                subNonPetitioned += r.nonPetitionedSeats;
+              }
+              return (
+                <React.Fragment key={`${g.cityTown}-${g.legDistrict}`}>
+                  <tr className="bg-gray-50 font-medium">
+                    <td colSpan={7} className="border border-gray-400 px-2 py-1">
+                      {g.cityTown}, LD {g.legDistrict}
+                    </td>
+                  </tr>
+                  {g.rows.map((r) => (
+                    <tr key={`${r.cityTown}-${r.legDistrict}-${r.electionDistrict}`}>
+                      <td className="border border-gray-400 px-2 py-1">{r.electionDistrict}</td>
+                      <td className="border border-gray-400 px-2 py-1 text-right">{r.totalSeats}</td>
+                      <td className="border border-gray-400 px-2 py-1 text-right">{r.filledSeats}</td>
+                      <td className="border border-gray-400 px-2 py-1 text-right">{r.vacantSeats}</td>
+                      <td className="border border-gray-400 px-2 py-1 text-right">
+                        {r.petitionedSeats - r.vacantPetitionedSeats}
+                      </td>
+                      <td className="border border-gray-400 px-2 py-1 text-right">{r.vacantPetitionedSeats}</td>
+                      <td className="border border-gray-400 px-2 py-1 text-right">{r.nonPetitionedSeats}</td>
+                    </tr>
+                  ))}
+                  <tr className="bg-gray-100 font-medium">
+                    <td className="border border-gray-400 px-2 py-1">Subtotal</td>
+                    <td className="border border-gray-400 px-2 py-1 text-right">{subTotal}</td>
+                    <td className="border border-gray-400 px-2 py-1 text-right">{subFilled}</td>
+                    <td className="border border-gray-400 px-2 py-1 text-right">{subVacant}</td>
+                    <td className="border border-gray-400 px-2 py-1 text-right">
+                      {subPetitioned - subVacantPetitioned}
+                    </td>
+                    <td className="border border-gray-400 px-2 py-1 text-right">{subVacantPetitioned}</td>
+                    <td className="border border-gray-400 px-2 py-1 text-right">{subNonPetitioned}</td>
+                  </tr>
+                </React.Fragment>
+              );
+            })}
+            <tr className="bg-gray-200 font-bold">
+              <td className="border border-gray-400 px-2 py-1">Grand Total</td>
+              <td className="border border-gray-400 px-2 py-1 text-right">{grandTotalSeats}</td>
+              <td className="border border-gray-400 px-2 py-1 text-right">{grandFilled}</td>
+              <td className="border border-gray-400 px-2 py-1 text-right">{grandVacant}</td>
+              <td className="border border-gray-400 px-2 py-1 text-right">
+                {grandPetitioned - grandVacantPetitioned}
+              </td>
+              <td className="border border-gray-400 px-2 py-1 text-right">{grandVacantPetitioned}</td>
+              <td className="border border-gray-400 px-2 py-1 text-right">{grandNonPetitioned}</td>
+            </tr>
+          </tbody>
+        </table>
+        <div className="mt-4 flex justify-between text-xs">
+          <span>{generationDate}</span>
+          <span>{reportAuthor}</span>
+        </div>
+      </div>
+    );
+}
+
+VacancyReport.displayName = 'VacancyReport';
+export default VacancyReport;

--- a/apps/report-server/src/utils.ts
+++ b/apps/report-server/src/utils.ts
@@ -23,7 +23,15 @@ import type { SignInSheetMember } from './components/SignInSheet';
 import DesignationWeightSummaryReport, {
   groupWeightSummaries,
 } from './components/DesignationWeightSummary';
-import type { DesignationWeightSummary } from './committeeMappingHelpers';
+import VacancyReport from './components/VacancyReport';
+import ChangesReport from './components/ChangesReport';
+import PetitionOutcomesReport from './components/PetitionOutcomesReport';
+import type {
+  DesignationWeightSummary,
+  VacancyReportRow,
+  ChangesReportRow,
+  PetitionOutcomeRow,
+} from './committeeMappingHelpers';
 // Helper function to convert YYYY-MM-DD format to "Month Day, Year" format
 function formatElectionDateForPetition(dateString: string): string {
   if (!dateString) return '';
@@ -305,6 +313,79 @@ export const generateDesignationWeightSummaryHTML = (
       <html>
         <head>
           <title>Designation Weight Summary</title>
+          ${tailwindCSS}
+        </head>
+        <body>
+          ${html}
+        </body>
+      </html>`;
+};
+
+export const generateVacancyReportHTML = (
+  rows: VacancyReportRow[],
+  reportAuthor: string,
+): string => {
+  const tailwindCSS =
+    '<link href="http://localhost:8080/tailwind.css" rel="stylesheet">';
+  const html = ReactDOMServer.renderToStaticMarkup(
+    React.createElement(VacancyReport, { rows, reportAuthor: reportAuthor ?? '' }),
+  );
+  return `<!DOCTYPE html>
+      <html>
+        <head>
+          <title>Vacancy Report</title>
+          ${tailwindCSS}
+        </head>
+        <body>
+          ${html}
+        </body>
+      </html>`;
+};
+
+export const generateChangesReportHTML = (
+  rows: ChangesReportRow[],
+  dateFrom: string,
+  dateTo: string,
+  reportAuthor: string,
+): string => {
+  const tailwindCSS =
+    '<link href="http://localhost:8080/tailwind.css" rel="stylesheet">';
+  const html = ReactDOMServer.renderToStaticMarkup(
+    React.createElement(ChangesReport, {
+      rows,
+      dateFrom,
+      dateTo,
+      reportAuthor: reportAuthor ?? '',
+    }),
+  );
+  return `<!DOCTYPE html>
+      <html>
+        <head>
+          <title>Committee Changes</title>
+          ${tailwindCSS}
+        </head>
+        <body>
+          ${html}
+        </body>
+      </html>`;
+};
+
+export const generatePetitionOutcomesReportHTML = (
+  rows: PetitionOutcomeRow[],
+  reportAuthor: string,
+): string => {
+  const tailwindCSS =
+    '<link href="http://localhost:8080/tailwind.css" rel="stylesheet">';
+  const html = ReactDOMServer.renderToStaticMarkup(
+    React.createElement(PetitionOutcomesReport, {
+      rows,
+      reportAuthor: reportAuthor ?? '',
+    }),
+  );
+  return `<!DOCTYPE html>
+      <html>
+        <head>
+          <title>Petition Outcomes Report</title>
           ${tailwindCSS}
         </head>
         <body>

--- a/docs/SRS/REPORT_PARAMETER_MATRIX.md
+++ b/docs/SRS/REPORT_PARAMETER_MATRIX.md
@@ -1,0 +1,15 @@
+# Report Parameter Matrix
+
+Consolidated reference for all report types (SRS 3.4).
+
+| Report Type | Formats | Scope Options | Extra Params | Leader Access | Admin Access |
+|-------------|---------|---------------|--------------|---------------|--------------|
+| Committee Roster (`ldCommittees`) | PDF, XLSX | Countywide | Field selection, column order | No | Yes |
+| Voter List | XLSX | N/A (search-based) | Search query, field selection | No | Yes |
+| Designated Petition | PDF | N/A (payload-based) | Candidates, party, appointments | Yes | Yes |
+| Absentee Report | XLSX | N/A (CSV-based) | CSV file | No | Yes |
+| Sign-In Sheet | PDF | Jurisdiction, Countywide | Meeting date (optional) | Jurisdiction only | Both |
+| Designation Weight Summary | PDF, XLSX | Jurisdiction, Countywide | — | Jurisdiction only | Both |
+| Vacancy Report | PDF, XLSX | Jurisdiction, Countywide | Vacancy filter | Jurisdiction only | Both |
+| Changes Report | PDF, XLSX | Jurisdiction, Countywide | Date range (required) | Jurisdiction only | Both |
+| Petition Outcomes Report | PDF, XLSX | Jurisdiction, Countywide | — | Jurisdiction only | Both |

--- a/docs/SRS/tickets/3.4-code-review.md
+++ b/docs/SRS/tickets/3.4-code-review.md
@@ -1,0 +1,181 @@
+# Code Review: Ticket 3.4 — Vacancy, Changes, and Petition Outcomes Reports UI
+
+**Reviewer:** AI Code Review  
+**Date:** 2025-02-21  
+**Ticket:** [3.4-vacancy-changes-petition-reports-ui.md](./3.4-vacancy-changes-petition-reports-ui.md)
+
+---
+
+## Executive Summary
+
+The implementation of ticket 3.4 is **largely complete and well-aligned with the specification**. All three report types (Vacancy, Changes, Petition Outcomes) are implemented end-to-end with schemas, data fetching, PDF/XLSX generation, frontend forms, and API integration. A few minor issues and suggestions are noted below.
+
+---
+
+## 1. Schema & Validation (shared-validators)
+
+### ✅ Correct
+
+- **vacancyReportSchema**, **changesReportSchema**, **petitionOutcomesReportSchema** added with correct fields
+- **REPORT_TYPE_MAPPINGS** includes all 3 new types with correct `databaseValue` and `filename`
+- Schemas include `scope`, `cityTown`, `legDistrict` where required
+- `vacancyFilter` defaults to `vacantOnly`
+- `dateFrom`/`dateTo` required for changes report
+- `enrichedReportDataSchema` extended for all 3 types
+
+### ⚠️ Minor
+
+- **Ticket vs implementation**: Ticket shows `reportAuthor` and `jobId` in the base schema; these are correctly in `enrichedReportDataSchema` only. No change needed.
+- **Date validation**: `dateFrom`/`dateTo` use `z.string()` without `.datetime()` or ISO date refinement. The report-server validates with `new Date()` and checks `getTime()`. Consider adding `z.string().regex(/^\d{4}-\d{2}-\d{2}$/)` or similar if strict ISO date format is desired at the API boundary.
+
+---
+
+## 2. Data Fetching (committeeMappingHelpers)
+
+### ✅ Correct
+
+- **fetchVacancyData**: Uses `committeeGovernanceConfig.maxSeatsPerLted`, scope/jurisdiction filtering, vacancy filter, correct seat math (petitioned filled/vacant, non-petitioned)
+- **fetchChangesData**: Queries memberships by lifecycle timestamps (`activatedAt`, `resignedAt`, `removedAt`, `confirmedAt`, `petitionPrimaryDate`), maps to change types (Added, Resigned, Removed, Confirmed, Petition Won, Petition Lost), sorts by `changeDate` descending
+- **fetchPetitionOutcomesData**: Two-query approach (ACTIVE with `petitionSeatNumber` + PETITIONED_LOST/PETITIONED_TIE) correctly covers all outcomes
+- **getPetitionOutcomeLabel**: Implements Won/Unopposed/Lost/Tie mapping per ticket
+- All fetchers throw when `scope === 'jurisdiction'` and `cityTown` is empty
+
+### ⚠️ Minor / Suggestions
+
+1. **Changes report – scope filtering**: Memberships are fetched without committee scope, then filtered in JS. For large counties with jurisdiction scope, an optimization would be to pre-fetch committee IDs and add `committeeListId: { in: committeeIds }` to the Prisma `where`. Current approach is correct but may be less efficient at scale.
+
+2. **Petition outcomes – PETITIONED_LOST with null seat**: Ticket states "Lost primary; seatNumber is null". Lost candidates are grouped under `petitionSeatNumber ?? 0`, creating a synthetic "Seat 0" group. This is a reasonable interpretation; consider adding a short comment explaining this for future maintainers.
+
+3. **Vacancy – committeeGovernanceConfig**: Uses `findFirst()` with no `where`. If multiple config rows exist, ordering is unspecified. Consider `findFirst({ orderBy: { ... } })` or `findUnique` if a single config is assumed.
+
+---
+
+## 3. PDF Components (report-server)
+
+### ✅ Correct
+
+- **VacancyReport**: Landscape table, grouped by city/LD, subtotals, grand total. Columns: ED, Total Seats, Filled, Vacant, Petitioned (Filled), Petitioned (Vacant), Non-Petitioned.
+- **ChangesReport**: Portrait table, date range in header, grouped by date (descending). Columns: Date, Member Name, City/Town, LD, ED, Change Type, Details.
+- **PetitionOutcomesReport**: Landscape, grouped by committee, color coding (Won/Unopposed green, Tie amber, Lost default). Columns: Seat #, Candidate Name, Vote Count, Outcome, Primary Date.
+
+### ⚠️ Minor
+
+1. **ChangesReport – row ordering**: Rows are grouped by date but within each date group, order is arbitrary (array order from Map). Consider secondary sort by `changeType` or `memberName` for consistent output.
+
+2. **PetitionOutcomesReport – ref**: The component uses `React.forwardRef` but the `ref` is passed to the root div and never used by the parent (utils.ts uses `renderToStaticMarkup`). Harmless; could remove ref if not needed for PDF rendering.
+
+---
+
+## 4. XLSX Generation
+
+### ✅ Correct
+
+- Vacancy, Changes, and Petition Outcomes each have dedicated `generate*XLSXAndUpload` functions
+- Column headers match PDF columns
+- Worksheet names sanitized via `sanitizeWorksheetName`
+
+### ⚠️ Minor
+
+- **xlsxGenerator import**: Imports `VacancyReportRow`, `ChangesReportRow`, `PetitionOutcomeRow` from `./committeeMappingHelpers`. Path is correct. Types are re-exported from committeeMappingHelpers; no duplication.
+
+---
+
+## 5. Process Job (report-server index.ts)
+
+### ✅ Correct
+
+- Handlers for `vacancyReport`, `changesReport`, `petitionOutcomesReport` extract scope, cityTown, legDistrict, and type-specific params
+- Validation for required fields (dateFrom/dateTo, cityTown when jurisdiction)
+- Correct calls to `fetchVacancyData`, `fetchChangesData`, `fetchPetitionOutcomesData`
+- Correct routing to PDF vs XLSX based on `format`
+
+### ⚠️ Minor
+
+- **Typo**: Line 424: `"calling callback url for report comple"` → should be `"report complete"`.
+
+---
+
+## 6. Frontend Forms
+
+### ✅ Correct
+
+- **VacancyReportForm**: Name, format, scope, city/town, leg district (Rochester), vacancy filter (vacant only / show all). Scope and jurisdiction logic match 3.2/3.3.
+- **ChangesReportForm**: Same scope pattern + date range (default last 30 days). Validation for dateFrom ≤ dateTo.
+- **PetitionOutcomesReportForm**: Scope and jurisdiction only; no extra params.
+- Leader scope restrictions: Leaders default to jurisdiction, cannot select countywide (enforced in API).
+- All forms use `ReportStatusTracker` and `useApiMutation`.
+
+### ⚠️ Minor
+
+1. **reportUtils.formatReportType**: Ticket says "Update formatReportType() for all 3 types". Current implementation uses `reportType.replace(/([A-Z])/g, " $1").trim()` — a generic transform that already produces "Vacancy Report", "Changes Report", "Petition Outcomes Report" from the ReportType enum. No explicit mapping needed; behavior is correct.
+
+2. **Unused state**: `reportUrl` is set in `onComplete` but the success link uses it. In VacancyReportForm, `setReportUrl(null)` is called on submit, so the link only shows after completion. Correct. Same pattern in all three forms.
+
+---
+
+## 7. API Route (generateReport)
+
+### ✅ Correct
+
+- `scopeReportTypes` includes `vacancyReport`, `changesReport`, `petitionOutcomesReport`
+- 403 for Leaders requesting countywide
+- Jurisdiction validation via `committeeMatchesJurisdictions` for scope `jurisdiction`
+- Report creation with correct `ReportType`
+
+---
+
+## 8. Report Parameter Matrix
+
+### ✅ Correct
+
+- `docs/SRS/REPORT_PARAMETER_MATRIX.md` exists and matches the ticket’s specification for all report types, including the 3 new ones.
+
+---
+
+## 9. Tests
+
+### ✅ Correct
+
+- **committeeMappingHelpers.test.ts**: Tests for `fetchVacancyData`, `fetchChangesData`, `fetchPetitionOutcomesData` (scope/date validation, error cases), and `getPetitionOutcomeLabel`
+- **generateReport.test.ts**: Tests for vacancyReport (403 countywide Leader, 200 Admin countywide)
+- **reportTypeMapping.test.ts**: Coverage for new report types
+
+### ⚠️ Gaps
+
+1. **Frontend form validation**: No tests for form validation (date range, cityTown required, etc.). Consider adding tests for `validate()` logic.
+
+2. **Integration**: Ticket calls for "Generate one report of each type and verify output." No automated integration test found. Manual verification recommended.
+
+3. **PDF component structure**: No tests that assert PDF HTML structure (e.g., correct table headers, grouping). Could add snapshot or structure tests if desired.
+
+---
+
+## 10. Prisma & Metadata
+
+### ✅ Correct
+
+- `ReportType` enum includes `VacancyReport`, `ChangesReport`, `PetitionOutcomesReport`
+- `reportMetadata.ts` includes the new types in `ReportMetadataMap` with `null` metadata
+
+### ⚠️ Migration Note (from ticket)
+
+- Ticket notes that schema changes are in place but migration may need to be created after merging 3.3. Confirm migration exists or run:
+  `pnpm --filter voter-file-tool exec prisma migrate dev --name add_vacancy_changes_petition_report_types`
+
+---
+
+## 11. Summary of Recommended Actions
+
+| Priority | Item |
+|----------|------|
+| Low | Fix typo: "report comple" → "report complete" in index.ts |
+| Low | Add comment in `fetchPetitionOutcomesData` explaining PETITIONED_LOST with null seat grouped as seat 0 |
+| Optional | Add `.regex()` or refinements for `dateFrom`/`dateTo` in changes schema if strict API validation is desired |
+| Optional | Add frontend form validation tests |
+| Optional | Add integration test or manual checklist for end-to-end report generation |
+
+---
+
+## Conclusion
+
+The implementation meets the ticket’s acceptance criteria. Code structure is consistent with existing patterns (3.2, 3.3), types are strict, and the report parameter matrix is documented. The items above are minor refinements rather than blocking issues.

--- a/docs/SRS/tickets/3.4-vacancy-changes-petition-reports-ui.md
+++ b/docs/SRS/tickets/3.4-vacancy-changes-petition-reports-ui.md
@@ -5,6 +5,8 @@
 **Effort:** 2–3 days
 **Depends on:** [2.6 Petition + Primary Outcome Tracking](2.6-petition-primary-outcome-tracking.md), [3.2 Sign-In Sheet Report UI](3.2-sign-in-sheet-report-ui.md)
 
+**Migration note:** Schema changes for `ReportType` enum are in place; no migration file in this worktree (to avoid conflicts with 3.3). After merging 3.3 into this branch, run `pnpm --filter voter-file-tool exec prisma migrate dev --name add_vacancy_changes_petition_report_types` to create the migration.
+
 ## Summary
 
 Add the final 3 report types: Vacancy Report, Changes Report, and Petition Outcomes Report. These reports share a common form pattern (established in 3.2/3.3) with scope + date range + format parameters. This ticket also produces the consolidated report parameter matrix for all report types.

--- a/packages/shared-validators/src/__tests__/reportTypeMapping.test.ts
+++ b/packages/shared-validators/src/__tests__/reportTypeMapping.test.ts
@@ -29,6 +29,9 @@ describe('REPORT_TYPE_MAPPINGS', () => {
       'VoterImport',
       'SignInSheet',
       'DesignationWeightSummary',
+      'VacancyReport',
+      'ChangesReport',
+      'PetitionOutcomesReport',
     ];
     Object.values(REPORT_TYPE_MAPPINGS).forEach((mapping) => {
       expect(validReportTypes).toContain(mapping.databaseValue);
@@ -65,6 +68,11 @@ describe('getPrismaReportType', () => {
     expect(getPrismaReportType('designationWeightSummary')).toBe(
       'DesignationWeightSummary',
     );
+    expect(getPrismaReportType('vacancyReport')).toBe('VacancyReport');
+    expect(getPrismaReportType('changesReport')).toBe('ChangesReport');
+    expect(getPrismaReportType('petitionOutcomesReport')).toBe(
+      'PetitionOutcomesReport',
+    );
   });
 });
 
@@ -80,6 +88,11 @@ describe('getFilenameReportType', () => {
     expect(getFilenameReportType('signInSheet')).toBe('signInSheet');
     expect(getFilenameReportType('designationWeightSummary')).toBe(
       'designationWeightSummary',
+    );
+    expect(getFilenameReportType('vacancyReport')).toBe('vacancyReport');
+    expect(getFilenameReportType('changesReport')).toBe('changesReport');
+    expect(getFilenameReportType('petitionOutcomesReport')).toBe(
+      'petitionOutcomesReport',
     );
   });
 });

--- a/packages/shared-validators/src/reportTypeMapping.ts
+++ b/packages/shared-validators/src/reportTypeMapping.ts
@@ -36,6 +36,18 @@ export const REPORT_TYPE_MAPPINGS = {
     databaseValue: 'DesignationWeightSummary' as ReportType,
     filename: 'designationWeightSummary',
   },
+  vacancyReport: {
+    databaseValue: 'VacancyReport' as ReportType,
+    filename: 'vacancyReport',
+  },
+  changesReport: {
+    databaseValue: 'ChangesReport' as ReportType,
+    filename: 'changesReport',
+  },
+  petitionOutcomesReport: {
+    databaseValue: 'PetitionOutcomesReport' as ReportType,
+    filename: 'petitionOutcomesReport',
+  },
 } as const;
 
 export type ReportTypeKey = keyof typeof REPORT_TYPE_MAPPINGS;

--- a/packages/shared-validators/src/schemas/report.ts
+++ b/packages/shared-validators/src/schemas/report.ts
@@ -172,6 +172,39 @@ const designationWeightSummaryReportSchema = z.object({
   legDistrict: z.number().optional(),
 });
 
+const vacancyReportSchema = z.object({
+  type: z.literal('vacancyReport'),
+  ...baseApiSchema.shape,
+  name: z.string(),
+  format: z.enum(['pdf', 'xlsx']),
+  scope: z.enum(['jurisdiction', 'countywide']),
+  cityTown: z.string().optional(),
+  legDistrict: z.number().optional(),
+  vacancyFilter: z.enum(['all', 'vacantOnly']).default('vacantOnly'),
+});
+
+const changesReportSchema = z.object({
+  type: z.literal('changesReport'),
+  ...baseApiSchema.shape,
+  name: z.string(),
+  format: z.enum(['pdf', 'xlsx']),
+  scope: z.enum(['jurisdiction', 'countywide']),
+  cityTown: z.string().optional(),
+  legDistrict: z.number().optional(),
+  dateFrom: z.string(),
+  dateTo: z.string(),
+});
+
+const petitionOutcomesReportSchema = z.object({
+  type: z.literal('petitionOutcomesReport'),
+  ...baseApiSchema.shape,
+  name: z.string(),
+  format: z.enum(['pdf', 'xlsx']),
+  scope: z.enum(['jurisdiction', 'countywide']),
+  cityTown: z.string().optional(),
+  legDistrict: z.number().optional(),
+});
+
 // Internal worker job schema (2.8). Not exposed in generateReportSchema.
 const boeEligibilityFlaggingReportSchema = z.object({
   type: z.literal('boeEligibilityFlagging'),
@@ -190,6 +223,9 @@ export const generateReportSchema = z.discriminatedUnion('type', [
   voterImportReportSchema,
   signInSheetReportSchema,
   designationWeightSummaryReportSchema,
+  vacancyReportSchema,
+  changesReportSchema,
+  petitionOutcomesReportSchema,
 ]);
 
 // Additional fields for enriched report data
@@ -226,6 +262,18 @@ export const enrichedReportDataSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     ...designationWeightSummaryReportSchema.shape,
+    ...enrichedFieldsSchema.shape,
+  }),
+  z.object({
+    ...vacancyReportSchema.shape,
+    ...enrichedFieldsSchema.shape,
+  }),
+  z.object({
+    ...changesReportSchema.shape,
+    ...enrichedFieldsSchema.shape,
+  }),
+  z.object({
+    ...petitionOutcomesReportSchema.shape,
     ...enrichedFieldsSchema.shape,
   }),
   z.object({


### PR DESCRIPTION
- Add vacancyReport, changesReport, petitionOutcomesReport schemas and type mappings
- Add fetchVacancyData, fetchChangesData, fetchPetitionOutcomesData in committeeMappingHelpers
- Add VacancyReport, ChangesReport, PetitionOutcomesReport PDF components
- Add XLSX generation for all 3 report types
- Add form pages: vacancy-reports, changes-reports, petition-outcomes-reports
- Enable all 3 cards in GenerateReportGrid
- Add ReportType enum migration (VacancyReport, ChangesReport, PetitionOutcomesReport)
- Add REPORT_PARAMETER_MATRIX.md and 3.4 code review doc
- Fix typo: report comple -> report complete in index.ts
- Add comment for PETITIONED_LOST null seat grouping